### PR TITLE
Fix behaviour for logging scripts

### DIFF
--- a/jboss/container/wildfly/launch-config/launch-common/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/launch-common/added/launch/openshift-common.sh
@@ -9,4 +9,24 @@ SERVER_CONFIG=${WILDFLY_SERVER_CONFIGURATION:-standalone.xml}
 CONFIG_FILE=$JBOSS_HOME/standalone/configuration/${SERVER_CONFIG}
 LOGGING_FILE=$JBOSS_HOME/standalone/configuration/logging.properties
 
+# Test an XpathExpression against server config file and returns
+# the xmllint exit code
+#
+# Parameters:
+# - $1      - the xpath expression to use
+# - $2      - the variable which will hold the result
+#
+function testXpathExpression() {
+  local xpath="$1"
+  unset -v "$2" || echo "Invalid identifier: $2" >&2
+
+  if [ "${SCRIPT_DEBUG}" == "true" ]; then
+    eval xmllint --xpath "${xpath}" "${CONFIG_FILE}"
+  else
+    eval xmllint --xpath "${xpath}" "${CONFIG_FILE}" 1>/dev/null
+  fi
+
+  printf -v "$2" '%s' "$?"
+}
+
 source ${JBOSS_HOME}/bin/launch/adjustment-mode.sh

--- a/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
+++ b/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
@@ -26,27 +26,26 @@ function configureByMarkers() {
 
 function configureByCLI() {
   if [ "${ENABLE_JSON_LOGGING^^}" == "TRUE" ]; then
-    cat <<'EOF' >> ${CLI_SCRIPT_FILE}
-      if (outcome != success) of /subsystem=logging/json-formatter=OPENSHIFT:read-resource
-        /subsystem=logging/json-formatter=OPENSHIFT:add(exception-output-type=formatted, key-overrides=[timestamp="@timestamp"], meta-data=[@version=1])
-      else
-        /subsystem=logging/json-formatter=OPENSHIFT:write-attribute(name=exception-output-type, value=formatted)
-        /subsystem=logging/json-formatter=OPENSHIFT:write-attribute(name=key-overrides, value=[timestamp="@timestamp"]
-        /subsystem=logging/json-formatter=OPENSHIFT:write-attribute(name=meta-data, value=[@version=1])
-      end-if
+
+    # We cannot have nested if sentences in CLI, so we use Xpath here to see if the subsystem=logging is in the file
+    xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:logging:')]\""
+    local ret
+    testXpathExpression "${xpath}" "ret"
+
+    if [ "${ret}" -eq 0 ]; then
+      cat <<'EOF' >> ${CLI_SCRIPT_FILE}
+          if (outcome != success) of /subsystem=logging/json-formatter=OPENSHIFT:read-resource
+            /subsystem=logging/json-formatter=OPENSHIFT:add(exception-output-type=formatted, key-overrides=[timestamp="@timestamp"], meta-data=[@version=1])
+          else
+            /subsystem=logging/json-formatter=OPENSHIFT:write-attribute(name=exception-output-type, value=formatted)
+            /subsystem=logging/json-formatter=OPENSHIFT:write-attribute(name=key-overrides, value=[timestamp="@timestamp"]
+            /subsystem=logging/json-formatter=OPENSHIFT:write-attribute(name=meta-data, value=[@version=1])
+          end-if
 EOF
-    consoleHandlerName "OPENSHIFT" >> ${CLI_SCRIPT_FILE}
+      consoleHandlerName "OPENSHIFT" >> ${CLI_SCRIPT_FILE}
+    fi
     sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $LOGGING_FILE
   else
-    local color_pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"
-cat <<EOF >> ${CLI_SCRIPT_FILE}
-      if (outcome != success) of  /subsystem=logging/pattern-formatter=COLOR-PATTERN:read-resource
-        /subsystem=logging/pattern-formatter=COLOR-PATTERN:add(pattern="${color_pattern}")
-      else
-        /subsystem=logging/pattern-formatter=COLOR-PATTERN:write-attribute(name=pattern, value="${color_pattern}")
-      end-if
-EOF
-    consoleHandlerName "COLOR-PATTERN" >> ${CLI_SCRIPT_FILE}
     sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $LOGGING_FILE
   fi
 }

--- a/jboss/container/wildfly/launch/json-logging/configure.sh
+++ b/jboss/container/wildfly/launch/json-logging/configure.sh
@@ -5,6 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 
+mkdir -p ${JBOSS_HOME}/standalone/configuration/
 cp -p ${ADDED_DIR}/logging.properties ${JBOSS_HOME}/standalone/configuration/
 
 mkdir -p ${JBOSS_HOME}/bin/launch/


### PR DESCRIPTION
Summary

- Do not modify the config if the mode is "cli"
- Do not modify the config logging subsystem is not present
- Use cp -p when copy

@jfdenise these are the changes discussed this morning