### PR TITLE
Fix processEnvFiles invokation using a parametrized verion to call th…

### DIFF
--- a/jboss/container/wildfly/launch-config/os/added/launch/configure-modules.sh
+++ b/jboss/container/wildfly/launch-config/os/added/launch/configure-modules.sh
@@ -96,17 +96,18 @@ function executeEnvModules() {
 # file processing, and keeps the base environment the same from file to file
 # (i.e. we don't have to run prepareEnv for each file).
 function processEnvFiles() {
+  local method=$1
   if [ -n "$ENV_FILES" ]; then
     (
-      executeModules prepareEnv
+      eval ${method} prepareEnv
       for prop_file_arg in $(echo $ENV_FILES | sed "s/,/ /g"); do
         for prop_file in $(find $prop_file_arg -maxdepth 0 2>/dev/null); do
           (
             if [ -f $prop_file ]; then
               source $prop_file
-              executeModules preConfigureEnv
-              executeModules configureEnv
-              executeModules postConfigureEnv
+              eval ${method} preConfigureEnv
+              eval ${method} configureEnv
+              eval ${method} postConfigureEnv
             else
               log_warning "Could not process environment for $prop_file.  File does not exist."
             fi
@@ -120,12 +121,13 @@ function processEnvFiles() {
 function configureConfigModules() {
   executeConfigModules preConfigure
   executeConfigModules configure
+  processEnvFiles executeConfigModules
   executeConfigModules postConfigure
 }
 
 function configureEnvModules() {
   executeEnvModules preConfigure
   executeEnvModules configure
-  processEnvFiles
+  processEnvFiles executeEnvModules
   executeEnvModules postConfigure
 }


### PR DESCRIPTION
…e method for config and environment modules

Fix the execution of the cekit scripts. In the original launch module (https://github.com/jboss-container-images/jboss-eap-modules/blob/master/os-eap-launch/added/launch/configure.sh#L111) we had the following execution:

```
executeModules preConfigure
executeModules configure
processEnvFiles
executeModules postConfigure
```
for each script configured in the target array.

This patch fix wildfly-cekit to use the same order and invoke the env files for the wilfly-ckit target arrays CONFIGURE_CONFIG_SCRIPTS and CONFIGURE_ENV_SCRIPTS.

Keep in mind we are executing the cli scripts after processing CONFIGURE_CONFIG_SCRIPTS.
This seems to be the initial intention, discussed in Zulip. The embedded server launched to execute the CLI operations should not depend on any variable or processing from the scripts configured in CONFIGURE_ENV_SCRIPTS



