### PR TITLE
 Additional fixes for JGroups and exec cli function

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
@@ -128,6 +128,11 @@ function exec_cli_scripts() {
     CLI_DEBUG="TRUE";
   fi
 
+  # remove any empty line
+  if [ -f "${script}" ]; then
+    sed -i '/^$/d' $script
+  fi
+
   if [ -s "${script}" ]; then
 
     # Dump the cli script file for debugging
@@ -177,6 +182,8 @@ function exec_cli_scripts() {
       exit 1
     elif [ -s "${CLI_SCRIPT_ERROR_FILE}" ]; then
       echo "Error applying ${CLI_SCRIPT_FILE_FOR_EMBEDDED} CLI script. Embedded server started successful. The Operations were executed but there were unexpected values. See list of errors in ${CLI_SCRIPT_ERROR_FILE}"
+      echo "================= CLI Error file ================="
+      cat ${CLI_SCRIPT_ERROR_FILE}
       exit 1
     elif [ "${SCRIPT_DEBUG}" != "true" ] ; then
       rm ${script} 2> /dev/null

--- a/jboss/container/wildfly/launch/jgroups/added/launch/ha.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/ha.sh
@@ -168,9 +168,9 @@ generate_generic_ping_config() {
       if [ $ret -eq 0 ]; then
         local stacks=(tcp udp)
         for stack in "${stacks[@]}"; do
-          local op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add()"
+          local op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add(add-index=0)"
           if [ "${socket_binding}x" != "x" ]; then
-            op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add(socket-binding=${socket_binding})"
+            op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add(add-index=0, socket-binding=${socket_binding})"
           fi
           config="${config} $(configureProtocolCliHelper "$stack" "${ping_protocol}" "${op}")"
         done
@@ -216,9 +216,9 @@ generate_dns_ping_config() {
       if [ $ret -eq 0 ]; then
         local stacks=(tcp udp)
         for stack in "${stacks[@]}"; do
-          local op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add()"
+          local op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add(add-index=0)"
           if [ "${socket_binding}x" != "x" ]; then
-            op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add(socket-binding=${socket_binding})"
+            op="/subsystem=jgroups/stack=$stack/protocol=${ping_protocol}:add(add-index=0, socket-binding=${socket_binding})"
           fi
 
           local op_prop1=""


### PR DESCRIPTION
- Additional fixes for ha.sh in jgroups
- Removes trailing new line from final generated CLI file to ensure we do not start embedded server if the file is empty
- prints error file in case of CLI errors were found