### PR TITLE
Extends user settings with galleon local maven cache. 

### DIFF
--- a/jboss/container/wildfly/s2i/bash/configure.sh
+++ b/jboss/container/wildfly/s2i/bash/configure.sh
@@ -17,3 +17,35 @@ ln -s /opt/jboss/container/wildfly/s2i/install-common/install-common.sh /usr/loc
 chown -h jboss:root /usr/local/s2i/install-common.sh
 
 mkdir $WILDFLY_S2I_OUTPUT_DIR && chown -R jboss:root $WILDFLY_S2I_OUTPUT_DIR && chmod -R ug+rwX $WILDFLY_S2I_OUTPUT_DIR
+
+# In order for applications to benefit from Galleon already downloaded artifacts
+galleon_profile="<profile>\n\
+      <id>local-galleon-repository</id>\n\
+      <activation><activeByDefault>true</activeByDefault></activation>\n\
+      <repositories>\n\
+        <repository>\n\
+          <id>local-galleon-repository</id>\n\
+          <url>file://$GALLEON_LOCAL_MAVEN_REPO</url>\n\
+          <releases>\n\
+            <enabled>true</enabled>\n\
+          </releases>\n\
+          <snapshots>\n\
+            <enabled>false</enabled>\n\
+          </snapshots>\n\
+        </repository>\n\
+      </repositories>\n\
+      <pluginRepositories>\n\
+        <pluginRepository>\n\
+          <id>local-galleon-plugin-repository</id>\n\
+          <url>file://$GALLEON_LOCAL_MAVEN_REPO</url>\n\
+          <releases>\n\
+            <enabled>true</enabled>\n\
+          </releases>\n\
+          <snapshots>\n\
+            <enabled>false</enabled>\n\
+          </snapshots>\n\
+        </pluginRepository>\n\
+      </pluginRepositories>\n\
+    </profile>\n\
+"
+sed -i "s|<\!-- ### configured profiles ### -->|$galleon_profile <\!-- ### configured profiles ### -->|" $HOME/.m2/settings.xml


### PR DESCRIPTION
Adding local galleon maven repo to user settings.xml @bstansberry @luck3y  that is the way the user will benefit from already downloaded artifacts without having an impact on incremental build.
The visible effect is that this repository is tried first to retrieve artifacts even for artifacts not already downloaded.