### PR TITLE
Configure logger categories using CLI scripts

### DIFF
--- a/jboss/container/wildfly/launch/logger-category/added/launch/configure_logger_category.sh
+++ b/jboss/container/wildfly/launch/logger-category/added/launch/configure_logger_category.sh
@@ -14,7 +14,6 @@
 #            <logger category="com.my.other.package">
 #                <level name="TRACE"/>
 #            </logger>
-
 source $JBOSS_HOME/bin/launch/logging.sh
 
 prepareEnv() {
@@ -25,27 +24,58 @@ configure() {
   add_logger_category
 }
 
+preConfigure() {
+  local configureMode
+  getConfigurationMode "<!-- ##LOGGER-CATEGORY## -->" "configureMode"
+  WORK_MODE=${configureMode}
+}
+
+postConfigure() {
+  unset WORK_MODE
+}
+
 add_logger_category() {
     # JUL implementation: https://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html
     # Plus JBoss logging levels
     local allowed_log_levels=("ALL" "SEVERE" "ERROR" "WARNING" "INFO" "CONFIG" "FINE" "DEBUG" "FINER" "FINEST" "TRACE")
 
     local IFS=","
-    if [ "x${LOGGER_CATEGORIES}" != "x" ] && grep -q '<!-- ##LOGGER-CATEGORY## -->' ${CONFIG_FILE}; then
+    if [ "x${LOGGER_CATEGORIES}" != "x" ]; then
+
+        if [ "${WORK_MODE}" = "cli" ]; then
+              xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:logging:')]\""
+              local ret
+              testXpathExpression "${xpath}" "ret"
+              if [ "${ret}" -ne 0 ]; then
+                break;
+              fi
+        fi
+
         log_info "Found env LOGGER_CATEGORIES, configuring...."
         for i in ${LOGGER_CATEGORIES}; do
             logger=$(echo "$i" | sed 's/ //g')
             logger_category=$(echo $logger | awk -F':' '{print $1}')
             logger_level=$(echo $logger | awk -F':' '{print $2}')
+
             if [[ ! "${allowed_log_levels[@]}" =~ " ${logger_level}" ]]; then
                  log_warning "Log Level ${logger_level} is not allowed, the allowed levels are ${allowed_log_levels[@]}"
-            else
+            elif [ "${WORK_MODE}" = "xml" ]; then
                 log_info "Configuring logger category ${logger_category} with level ${logger_level:-FINE}"
                 logger="<logger category=\"${logger_category}\">\n                \
 <level name=\"${logger_level:-FINE}\"/>\n\            \
 </logger>\n            \
 <!-- ##LOGGER-CATEGORY## -->"
                 sed -i "s|<!-- ##LOGGER-CATEGORY## -->|${logger}|" $CONFIG_FILE
+            elif [ "${WORK_MODE}" = "cli" ]; then
+              log_info "Configuring logger category ${logger_category} with level ${logger_level:-FINE}"
+
+              cat << EOF >> ${CLI_SCRIPT_FILE}
+              if (outcome == success) of /subsystem=logging/logger=${logger_category}:read-resource
+                /subsystem=logging/logger=${logger_category}:write-attribute(name=level, value=${logger_level:-FINE})
+              else
+                /subsystem=logging/logger=${logger_category}:add(category=${logger_category},level=${logger_level:-FINE})
+              end-if
+EOF
             fi
         done
     fi

--- a/jboss/container/wildfly/launch/logger-category/tests/configure-logging-category.bats
+++ b/jboss/container/wildfly/launch/logger-category/tests/configure-logging-category.bats
@@ -24,22 +24,25 @@ teardown() {
   rm -rf $JBOSS_HOME
 }
 
+run_logger_category_script() {
+  preConfigure
+  configure
+  postConfigure
+}
+
 # note the <test>...</test> wrapper is used to allow xmllint to reformat (it requires a root node) so comparisons are more robust between different versions
 # of xmllint etc.
 
 
 @test "Add 1 logger category" {
-  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package']" $CONFIG_FILE
   expected=$(cat <<EOF
-<logger category="com.arjuna"><level name="WARN"/></logger>
-<logger category="org.jboss.as.config"><level name="DEBUG"/></logger>
-<logger category="sun.rmi"><level name="WARN"/></logger>
 <logger category="com.my.package"><level name="DEBUG"/></logger>
 EOF
 )
   LOGGER_CATEGORIES=com.my.package:DEBUG
-  run add_logger_category
-  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE)
+  run run_logger_category_script
+  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package']" $CONFIG_FILE)
   result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
   expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
   echo "Expected: ${expected}"
@@ -48,18 +51,15 @@ EOF
 }
 
 @test "Add 2 logger categories" {
-  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package']" $CONFIG_FILE
   expected=$(cat <<EOF
-<logger category="com.arjuna"><level name="WARN"/></logger>
-<logger category="org.jboss.as.config"><level name="DEBUG"/></logger>
-<logger category="sun.rmi"><level name="WARN"/></logger>
 <logger category="com.my.package"><level name="DEBUG"/></logger>
 <logger category="my.other.package"><level name="ERROR"/></logger>
 EOF
 )
   LOGGER_CATEGORIES=com.my.package:DEBUG,my.other.package:ERROR
-  run add_logger_category
-  result=$(xmllint -xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE)
+  run run_logger_category_script
+  result=$(xmllint -xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package']" $CONFIG_FILE)
   result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
   expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
   echo "Expected: ${expected}"
@@ -68,19 +68,16 @@ EOF
 }
 
 @test "Add 3 logger categories, one with no log level" {
-  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package' or @category='my.another.package']" $CONFIG_FILE
   expected=$(cat <<EOF
-<logger category="com.arjuna"><level name="WARN"/></logger>
-<logger category="org.jboss.as.config"><level name="DEBUG"/></logger>
-<logger category="sun.rmi"><level name="WARN"/></logger>
 <logger category="com.my.package"><level name="DEBUG"/></logger>
 <logger category="my.other.package"><level name="ERROR"/></logger>
 <logger category="my.another.package"><level name="FINE"/></logger>
 EOF
 )
   LOGGER_CATEGORIES=com.my.package:DEBUG,my.other.package:ERROR,my.another.package
-  run add_logger_category
-  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE)
+  run run_logger_category_script
+  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package' or @category='my.another.package']" $CONFIG_FILE)
   result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
   expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
   echo "Expected: ${expected}"
@@ -89,19 +86,16 @@ EOF
 }
 
 @test "Add 3 logger categories with spaces" {
-  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE '
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package' or @category='my.another.package']" $CONFIG_FILE '
   expected=$(cat <<EOF
-<logger category="com.arjuna"><level name="WARN"/></logger>
-<logger category="org.jboss.as.config"><level name="DEBUG"/></logger>
-<logger category="sun.rmi"><level name="WARN"/></logger>
 <logger category="com.my.package"><level name="DEBUG"/></logger>
 <logger category="my.other.package"><level name="ERROR"/></logger>
 <logger category="my.another.package"><level name="FINE"/></logger>
 EOF
 )
   LOGGER_CATEGORIES=" com.my.package:DEBUG, my.other.package:ERROR, my.another.package"
-  run add_logger_category
-  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE)
+  run run_logger_category_script
+  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package' or @category='my.another.package']" $CONFIG_FILE)
   result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
   expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
   echo "Expected: ${expected}"
@@ -110,17 +104,14 @@ EOF
 }
 
 @test "Add 2 logger categories one with invalid log level" {
-  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package']" $CONFIG_FILE
   expected=$(cat <<EOF
-<logger category="com.arjuna"><level name="WARN"/></logger>
-<logger category="org.jboss.as.config"><level name="DEBUG"/></logger>
-<logger category="sun.rmi"><level name="WARN"/></logger>
 <logger category="com.my.package"><level name="DEBUG"/></logger>
 EOF
 )
   LOGGER_CATEGORIES=com.my.package:DEBUG,my.other.package:UNKNOWN_LOG_LEVEL
-  run add_logger_category
-  result=$(xmllint --format --noblanks --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE)
+  run run_logger_category_script
+  result=$(xmllint --format --noblanks --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package']" $CONFIG_FILE)
   result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
   expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
   echo "Expected: ${expected}"


### PR DESCRIPTION
- Enables the use of LOGGER_CATEGORIES env variable to work with CLI scripts.
- Fix logger categories bats tests