### PR TITLE
call offliner from tmp dir to allow for error.logs to be written

### DIFF
--- a/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
+++ b/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
@@ -32,9 +32,11 @@ curl -v -L http://repo.maven.apache.org/maven2/com/redhat/red/offliner/offliner/
 # Download offliner file
 curl -v -L $WILDFLY_DIST_MAVEN_LOCATION/$WILDFLY_VERSION/wildfly-dist-$WILDFLY_VERSION-artifact-list.txt > /tmp/offliner.txt
 
-# Populate maven repo
+# Populate maven repo, in case we have errors (occur when using locally built WildFly, no md5 nor sha files), cd to /tmp where error.logs is written.
+cd /tmp
 java -jar /tmp/offliner.jar $OFFLINER_URLS \
 /tmp/offliner.txt --dir $GALLEON_LOCAL_MAVEN_REPO > /dev/null
+cd ..
 
 rm /tmp/offliner.jar && rm /tmp/offliner.txt
 


### PR DESCRIPTION
Needed when replacing WildFly with localy built one.