### PR TITLE
Enable the security domain executions using CLI operations

### DIFF
--- a/jboss/container/wildfly/launch/security-domains/added/launch/security-domains.sh
+++ b/jboss/container/wildfly/launch/security-domains/added/launch/security-domains.sh
@@ -1,0 +1,84 @@
+
+function prepareEnv() {
+  unset SECDOMAIN_NAME
+  unset SECDOMAIN_USERS_PROPERTIES
+  unset SECDOMAIN_ROLES_PROPERTIES
+  unset SECDOMAIN_LOGIN_MODULE
+  unset SECDOMAIN_PASSWORD_STACKING
+}
+
+function configure() {
+  configure_security_domains
+}
+
+function configureEnv() {
+  configure
+}
+
+configure_security_domains() {
+  local usersProperties="\${jboss.server.config.dir}/${SECDOMAIN_USERS_PROPERTIES}"
+  local rolesProperties="\${jboss.server.config.dir}/${SECDOMAIN_ROLES_PROPERTIES}"
+
+  # CLOUD-431: Check if provided files are absolute paths
+  test "${SECDOMAIN_USERS_PROPERTIES:0:1}" = "/" && usersProperties="${SECDOMAIN_USERS_PROPERTIES}"
+  test "${SECDOMAIN_ROLES_PROPERTIES:0:1}" = "/" && rolesProperties="${SECDOMAIN_ROLES_PROPERTIES}"
+
+  local domains="<!-- no additional security domains configured -->"
+
+  if [ -n "$SECDOMAIN_NAME" ]; then
+    local login_module=${SECDOMAIN_LOGIN_MODULE:-UsersRoles}
+    local realm=""
+    local stack=""
+
+    local confMode
+    getConfigurationMode "<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->" "confMode"
+
+    if [ "${confMode}" = "xml" ]; then
+
+      if [ $login_module == "RealmUsersRoles" ]; then
+          realm="<module-option name=\"realm\" value=\"ApplicationRealm\"/>\n"
+      fi
+
+      if [ -n "$SECDOMAIN_PASSWORD_STACKING" ]; then
+          stack="<module-option name=\"password-stacking\" value=\"useFirstPass\"/>\n"
+      fi
+
+      domains="\
+        <security-domain name=\"$SECDOMAIN_NAME\" cache-type=\"default\">\n\
+            <authentication>\n\
+                <login-module code=\"$login_module\" flag=\"required\">\n\
+                    <module-option name=\"usersProperties\" value=\"${usersProperties}\"/>\n\
+                    <module-option name=\"rolesProperties\" value=\"${rolesProperties}\"/>\n\
+                    $realm\
+                    $stack\
+                </login-module>\n\
+            </authentication>\n\
+        </security-domain>\n"
+
+      sed -i "s|<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->|${domains}<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->|" "$CONFIG_FILE"
+
+    elif [ "${confMode}" = "cli" ]; then
+
+      local moduleOpts=("\"usersProperties\"=>\""${usersProperties}"\""
+                        "\"rolesProperties\"=>\""${rolesProperties}"\"")
+
+      if [ $login_module == "RealmUsersRoles" ]; then
+          moduleOpts+=("\"realm\"=>\"ApplicationRealm\"")
+      fi
+
+      if [ -n "$SECDOMAIN_PASSWORD_STACKING" ]; then
+          moduleOpts+=("\"password-stacking\"=>\"useFirstPass\"")
+      fi
+
+      cat << EOF >> ${CLI_SCRIPT_FILE}
+        if (outcome != success) of /subsystem=security/security-domain=${SECDOMAIN_NAME}:read-resource
+          /subsystem=security/security-domain=${SECDOMAIN_NAME}:add(cache-type=default)
+          /subsystem=security/security-domain=${SECDOMAIN_NAME}/authentication=classic:add(login-modules=[{code="${login_module}", flag=required, module-options=$(IFS=,; echo "{${moduleOpts[*]}}")}])
+        else
+          echo "You have set environment variables to configure the security domain '${SECDOMAIN_NAME}'. However, your base configuration already contains a security domain with that name." >> \${error_file}
+          quit
+        end-if
+EOF
+    fi
+  fi
+}

--- a/jboss/container/wildfly/launch/security-domains/configure.sh
+++ b/jboss/container/wildfly/launch/security-domains/configure.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+cp -p ${ADDED_DIR}/launch/security-domains.sh ${JBOSS_HOME}/bin/launch/
+chmod ug+x ${JBOSS_HOME}/bin/launch/security-domains.sh
+
+

--- a/jboss/container/wildfly/launch/security-domains/module.yaml
+++ b/jboss/container/wildfly/launch/security-domains/module.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+name: jboss.container.wildfly.launch.security-domains
+version: '1.0'
+description:
+
+execute:
+- script: configure.sh
+  user: '185'
+
+envs:
+  - name: "SECDOMAIN_NAME"
+    example: "myDomain"
+    description: "Defines an additional security domain."
+  - name: "SECDOMAIN_USERS_PROPERTIES"
+    example: "users.properties"
+    description: "The name of the properties file containing user definitions, defaults to users.properties"
+  - name: "SECDOMAIN_ROLES_PROPERTIES"
+    example: "roles.properties"
+    description: "The name of the properties file containing role definitions, defaults to roles.properties"
+  - name: "SECDOMAIN_LOGIN_MODULE"
+    example: "UsersRoles"
+    description: "The login module to be used, defaults to UsersRoles"
+  - name: "SECDOMAIN_PASSWORD_STACKING"
+    example: "true"
+    description: "If defined, the password-stacking module option is enabled and set to the value useFirstPass."

--- a/jboss/container/wildfly/launch/security-domains/tests/security-domains.bats
+++ b/jboss/container/wildfly/launch/security-domains/tests/security-domains.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+export BATS_TEST_SKIPPED=
+export JBOSS_HOME=$BATS_TMPDIR/jboss_home
+
+rm -rf $JBOSS_HOME
+mkdir -p $JBOSS_HOME/bin/launch
+cp $BATS_TEST_DIRNAME/../../../launch-config/config/added/launch/openshift-common.sh $JBOSS_HOME/bin/launch
+cp $BATS_TEST_DIRNAME/../added/launch/security-domains.sh $JBOSS_HOME/bin/launch
+mkdir -p $JBOSS_HOME/standalone/configuration
+
+# Set up the environment variables and load dependencies
+WILDFLY_SERVER_CONFIGURATION=standalone-openshift.xml
+source $JBOSS_HOME/bin/launch/openshift-common.sh
+load $BATS_TEST_DIRNAME/../added/launch/security-domains.sh
+
+setup() {
+  cp $BATS_TEST_DIRNAME/../../../../../../test-common/configuration/standalone-openshift.xml $JBOSS_HOME/standalone/configuration
+}
+
+teardown() {
+  if [ -n "${CONFIG_FILE}" ] && [ -f "${CONFIG_FILE}" ]; then
+    rm "${CONFIG_FILE}"
+  fi
+}
+
+@test "check security-domain configured" {
+  expected=$(cat <<EOF
+  <security-domain name="HiThere" cache-type="default">
+    <authentication>
+        <login-module code="RealmUsersRoles" flag="required">
+            <module-option name="usersProperties" value="\${jboss.server.config.dir}/my.user.properties"/>
+            <module-option name="rolesProperties" value="\${jboss.server.config.dir}/my.roles.properties"/>
+            <module-option name="realm" value="ApplicationRealm"/>
+            <module-option name="password-stacking" value="useFirstPass"/>
+        </login-module>
+    </authentication>
+  </security-domain>
+EOF
+)
+  SECDOMAIN_NAME=HiThere
+  SECDOMAIN_LOGIN_MODULE=RealmUsersRoles
+  SECDOMAIN_PASSWORD_STACKING=true
+  SECDOMAIN_USERS_PROPERTIES=my.user.properties
+  SECDOMAIN_ROLES_PROPERTIES=my.roles.properties
+
+  run configure
+
+  cat ${CONFIG_FILE}
+  result=$(xmllint --xpath "//*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']" $CONFIG_FILE)
+
+  result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
+  expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
+  echo "Expected: ${expected}"
+  echo "Result: ${result}"
+  [ "${result}" = "${expected}" ]
+}

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -5,6 +5,7 @@ BATS_SERVER_CONFIG_FILE_DIRECTORY="${SCRIPT_DIR}/test-common/configuration"
 BATS_SERVER_CONFIG_FILE_NAME="standalone-openshift.xml"
 BATS_SERVER_CONFIG_FILE="${BATS_SERVER_CONFIG_FILE_DIRECTORY}/${BATS_SERVER_CONFIG_FILE_NAME}"
 BATS_CONFIG_ENV_FILE="${BATS_SERVER_CONFIG_FILE_DIRECTORY}/bats-config.env"
+FILE_TEST_PATTERN=${1:-"*.bats"}
 
 
 if [ -z "${BATS_STANDALONE_XML_URL}" ] && [ -f "${BATS_CONFIG_ENV_FILE}" ]; then
@@ -35,7 +36,7 @@ if [ "${1}" = "--tap" ]; then
     tap="--tap"
 fi
 
-for testName in `find ./ -name *.bats`;
+for testName in `find ./ -name "${FILE_TEST_PATTERN}"`;
 do
     echo ${testName};
     bats ${tap} ${testName}


### PR DESCRIPTION
In order to work properly with security domain markers, it needs minimum Wildfly-core 10.0.0.Beta3 due to https://issues.jboss.org/browse/WFCORE-4407

Behave tests pass with a server config without the related markers.

It also adds a convenience change to be able to run single bats tests by name, we could use ./run-all-test.sh security-domains.bats to execute only the security-domains bats tests