### PR TITLE
Fail-fast in the datasources subsystem

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -546,17 +546,17 @@ function generate_external_datasource_cli() {
 
   ds="
     if (outcome != success) of ${subsystem_addr}:read-resource
-      echo \"You have set environment variables to configure the datasource '${pool_name}'. Fix your configuration to contain a datasources subsystem for this to happen.\" >> \${error_file}
+      echo You have set environment variables to configure the datasource '${pool_name}'. Fix your configuration to contain a datasources subsystem for this to happen. >> \${error_file}
       exit
     end-if
 
     if (outcome == success) of ${ds_resource}:read-resource
-      echo \"You have set environment variables to configure the datasource '${pool_name}'. However, your base configuration already contains a datasource with that name.\" >> \${error_file}
+      echo You have set environment variables to configure the datasource '${pool_name}'. However, your base configuration already contains a datasource with that name. >> \${error_file}
       exit
     end-if
 
     if (outcome == success) of ${other_ds_resource}:read-resource
-      echo \"You have set environment variables to configure the datasource '${pool_name}'. However, your base configuration already contains a datasource with that name.\" >> \${error_file}
+      echo You have set environment variables to configure the datasource '${pool_name}'. However, your base configuration already contains a datasource with that name. >> \${error_file}
       exit
     end-if
 
@@ -618,17 +618,17 @@ function generate_default_datasource_cli() {
 
   ds="
     if (outcome != success) of ${subsystem_addr}:read-resource
-      echo \"You have set environment variables to configure the default datasource '${pool_name}'. Fix your configuration to contain a datasources subsystem for this to happen.\" >> \${error_file}
+      echo You have set environment variables to configure the default datasource '${pool_name}'. Fix your configuration to contain a datasources subsystem for this to happen. >> \${error_file}
       exit
     end-if
 
     if (outcome == success) of ${ds_resource}:read-resource
-      echo \"You have set environment variables to configure the default datasource '${pool_name}'. However, your base configuration already contains a datasource with that name.\" >> \${error_file}
+      echo You have set environment variables to configure the default datasource '${pool_name}'. However, your base configuration already contains a datasource with that name. >> \${error_file}
       exit
     end-if
 
     if (outcome == success) of ${xa_resource}:read-resource
-      echo \"You have set environment variables to configure the default datasource '${pool_name}'. However, your base configuration already contains a datasource with that name.\" >> \${error_file}
+      echo You have set environment variables to configure the default datasource '${pool_name}'. However, your base configuration already contains a datasource with that name. >> \${error_file}
       exit
     end-if
 

--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -693,8 +693,10 @@ function inject_timer_service() {
     local xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:ejb3:')]\""
     testXpathExpression "${xpath}" "hasEjb3Subsystem"
     if [ $hasEjb3Subsystem -ne 0 ]; then
-      # No ejb3 subsystem is an error
-      echo "You have set the TIMER_SERVICE_DATA_STORE environment variable which adds a timer-service to the ejb3 subsystem. Fix your configuration to contain an ejb3 subsystem for this to happen."
+      # No ejb3 subsystem is an error. We need to push this into the error file since this runs inside a sub-shell and
+      # any echo without a redirect here goes to the CLI file. Also any attempt to exit here only exits the sub-shell,
+      # Not the whole launch process
+      echo "You have set the TIMER_SERVICE_DATA_STORE environment variable which adds a timer-service to the ejb3 subsystem. Fix your configuration to contain an ejb3 subsystem for this to happen." >> ${CLI_SCRIPT_ERROR_FILE}
       exit 1
     else
       local timerResource="/subsystem=ejb3/service=timer-service"


### PR DESCRIPTION
A later iteration will also fail fast if the list of added datasources does not contain ones asked for in:
-DEFAULT_JOB_REPOSITORY
-TIMER_SERVICE_DATA_STORE
-EE_DEFAULT_DATASOURCE

Tests are in https://github.com/wildfly/temp-eap-modules/pull/40