### PR TITLE
Enable JGroups encryption via CLI operations

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
@@ -150,6 +150,24 @@ function processErrorsAndWarnings() {
   fi
 }
 
+# An XPath expression e.g getting all name attributes for all the servers in the undertow subsystem
+# will return a variable with all the attributes with their names on one line, e.g
+#     'name="server-one" name="server-two" name="server-three"'
+# Call this with ($input is the string above)
+#     convertAttributesToValueOnEachLine "$input" "name"
+# to convert this to :
+# "server-one
+# server-two
+# server-three"
+function splitAttributesStringIntoLinks() {
+  local input="${1}"
+  local attribute_name="${2}"
+
+  local temp
+  temp=$(echo $input | sed "s|\" ${attribute_name}=\"|\" \n${attribute_name}=\"|g" | awk -F "\"" '{print $2}')
+  echo "${temp}"
+}
+
 function exec_cli_scripts() {
   local script="$1"
   local stdOut="discard"

--- a/jboss/container/wildfly/launch/access-log-valve/added/launch/access_log_valve.sh
+++ b/jboss/container/wildfly/launch/access-log-valve/added/launch/access_log_valve.sh
@@ -216,24 +216,6 @@ function configure_access_log_handler() {
   fi
 }
 
-# An XPath expression e.g getting all name attributes for all the servers in the undertow subsystem
-# will return a variable with all the attributes with their names on one line, e.g
-#     'name="server-one" name="server-two" name="server-three"'
-# Call this with ($input is the string above)
-#     convertAttributesToValueOnEachLine "$input" "name"
-# to convert this to :
-# "server-one
-# server-two
-# server-three"
-function splitAttributesStringIntoLinks() {
-  local input="${1}"
-  local attribute_name="${2}"
-
-  local temp
-  temp=$(echo $input | sed "s|\" ${attribute_name}=\"|\" \n${attribute_name}=\"|g" | awk -F "\"" '{print $2}')
-  echo "${temp}"
-}
-
 function getPattern() {
   local mode="${1}"
   if [ "${mode}" = "add-xml" ]; then

--- a/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
@@ -1,17 +1,4 @@
-# only processes a single environment as the placeholder is not preserved
-
-if [ -n "${LOGGING_INCLUDE}" ]; then
-    source "${LOGGING_INCLUDE}"
-else
-    source $JBOSS_HOME/bin/launch/logging.sh
-fi
-
-# required shared elytron functions
-if [ -n "${ELYTRON_INCLUDE}" ]; then
-    source "${ELYTRON_INCLUDE}"
-else
-    source $JBOSS_HOME/bin/launch/elytron.sh
-fi
+source $JBOSS_HOME/bin/launch/jgroups_common.sh
 
 prepareEnv() {
   unset JGROUPS_ENCRYPT_SECRET
@@ -31,10 +18,57 @@ configureEnv() {
 
 create_jgroups_elytron_encrypt_sym() {
     declare jg_encrypt_keystore="$1" jg_encrypt_key_alias="$2" jg_encrypt_password="$3"
-    local encrypt="<encrypt-protocol type=\"SYM_ENCRYPT\" key-store=\"${jg_encrypt_keystore}\" key-alias=\"${jg_encrypt_key_alias}\">\
-                       <key-credential-reference clear-text=\"${jg_encrypt_password}\"/>\
-                   </encrypt-protocol>"
-    echo ${encrypt}
+    local encrypt
+    read -r -d '' encrypt <<- EOF
+    <encrypt-protocol type="SYM_ENCRYPT" key-store="${jg_encrypt_keystore}" key-alias="${jg_encrypt_key_alias}">
+       <key-credential-reference clear-text="${jg_encrypt_password}"/>
+    </encrypt-protocol>
+EOF
+
+    echo "${encrypt}"
+}
+
+create_jgroups_elytron_encrypt_sym_cli() {
+  declare jg_encrypt_keystore="$1" jg_encrypt_key_alias="$2" jg_encrypt_password="$3"
+
+  local protocolTypes
+  local xpath
+  local result
+  local index
+  local protocolType
+  local config
+  local missingNAKACK2="false"
+  local stacks=(tcp udp)
+
+  for stack in "${stacks[@]}"; do
+    xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='stack' and @name='${stack}']/*[local-name()='protocol']/@type\""
+    testXpathExpression "${xpath}" "result" "protocolTypes"
+    index=0
+    if [ ${result} -eq 0 ]; then
+      protocolTypes=$(splitAttributesStringIntoLinks "${protocolTypes}" "type")
+      arr=(${protocolTypes})
+      
+      while read -r protocolType; do
+        if [ "${protocolType}" = "pbcast.NAKACK2" ]; then
+          break
+        fi
+        ((index=index+1))
+      done <<< "${protocolTypes}"
+     
+      if [ ${index} -eq ${#arr[@]} ]; then
+        echo "You have set JGROUPS_CLUSTER_PASSWORD environment variable to configure SYM_ENCRYPT protocol but pbcast.NAKACK2 protocol was not found for ${stack^^} stack. Fix your configuration to contain the pbcast.NAKACK2 in the JGroups subsystem for this to happen." >> "${CLI_SCRIPT_ERROR_FILE}"
+        missingNAKACK2="true"
+        continue
+      fi
+    fi
+
+    op=("/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT:add(add-index=${index}, key-store=\"${jg_encrypt_keystore}\", key-alias=\"${jg_encrypt_key_alias}\", key-credential-reference={clear-text=\"${jg_encrypt_password}\"})")
+    config="${config} $(configure_protocol_cli_helper "${stack}" "SYM_ENCRYPT" "${op[@]}")"
+  done
+
+  if [ "${missingNAKACK2}" = "false" ]; then
+    echo "${config}"
+  fi
 }
 
 create_jgroups_encrypt_asym() {
@@ -43,31 +77,134 @@ create_jgroups_encrypt_asym() {
     # this also *requires* AUTH to be enabled.
     # TODO: make these properties configurable, this is currently just falling back on defaults.
     declare sym_keylength="${1:-}" sym_algorithm="${2:-}" asym_keylength="${3:-}" asym_algorithm="${4:-}" change_key_on_leave="${5:-}"
-    local jgroups_encrypt="\
-                    <protocol type=\"ASYM_ENCRYPT\">\n\
-                        <property name=\"sym_keylength\">${sym_keylength:-128}</property>\n\
-                        <property name=\"sym_algorithm\">${sym_algorithm:-AES/ECB/PKCS5Padding}</property>\n\
-                        <property name=\"asym_keylength\">${asym_keylength:-512}</property>\n\
-                        <property name=\"asym_algorithm\">${asym_algorithm:-RSA}</property>\n\
-                        <property name=\"change_key_on_leave\">${change_key_on_leave:-true}</property>\n\
-                    </protocol>"
-    echo ${jgroups_encrypt}
+    local jgroups_encrypt
+    read -r -d '' jgroups_encrypt <<- EOF
+      <protocol type="ASYM_ENCRYPT">
+          <property name="sym_keylength">${sym_keylength:-128}</property>
+          <property name="sym_algorithm">${sym_algorithm:-AES/ECB/PKCS5Padding}</property>
+          <property name="asym_keylength">${asym_keylength:-512}</property>
+          <property name="asym_algorithm">${asym_algorithm:-RSA}</property>
+          <property name="change_key_on_leave">${change_key_on_leave:-true}</property>
+      </protocol>
+EOF
+    echo "${jgroups_encrypt}"
+}
+
+create_jgroups_encrypt_asym_cli() {
+    declare sym_keylength="${1:-}" sym_algorithm="${2:-}" asym_keylength="${3:-}" asym_algorithm="${4:-}" change_key_on_leave="${5:-}"
+
+    local protocolTypes
+    local xpath
+    local result
+    local index
+    local protocolType
+    local config
+    local missingNAKACK2="false"
+    local stacks=(tcp udp)
+
+    for stack in "${stacks[@]}"; do
+      xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='stack' and @name='${stack}']/*[local-name()='protocol']/@type\""
+      testXpathExpression "${xpath}" "result" "protocolTypes"
+      index=0
+      if [ ${result} -eq 0 ]; then
+        protocolTypes=$(splitAttributesStringIntoLinks "${protocolTypes}" "type")
+        arr=($protocolTypes)
+
+        while read -r protocolType; do
+          if [ ${protocolType} == "pbcast.NAKACK2" ]; then
+            break
+          fi
+          ((index=index+1))
+        done <<< "${protocolTypes}"
+
+        if [ ${index} -eq ${#arr[@]} ]; then
+          echo "You have set JGROUPS_CLUSTER_PASSWORD environment variable to configure ASYM_ENCRYPT protocol but pbcast.NAKACK2 protocol was not found for ${stack^^} stack. Fix your configuration to contain the pbcast.NAKACK2 in the JGroups subsystem for this to happen." >> "${CLI_SCRIPT_ERROR_FILE}"
+          missingNAKACK2="true"
+          continue
+        fi
+      fi
+      op=("/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT:add(add-index=${index})"
+          "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=sym_keylength:add(value=\"${sym_keylength:-128}\")"
+          "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=sym_algorithm:add(value=\"${sym_algorithm:-AES/ECB/PKCS5Padding}\")"
+          "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=asym_keylength:add(value=\"${asym_keylength:-512}\")"
+          "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value=\"${change_key_on_leave:-true}\")"
+      )
+      config="${config} $(configure_protocol_cli_helper "${stack}" "ASYM_ENCRYPT" "${op[@]}")"
+    done
+
+    if [ "${missingNAKACK2}" = "false" ]; then
+      echo "${config}"
+    fi
 }
 
 create_jgroups_elytron_legacy() {
     declare jg_encrypt_keystore="$1" jg_encrypt_password="$2" jg_encrypt_name="$3" jg_encrypt_keystore_dir="$4"
     # compatibility with old marker, only used if new marker is not present
-    local legacy_encrypt="\
-        <protocol type=\"SYM_ENCRYPT\">\
-          <property name=\"provider\">SunJCE</property>\
-          <property name=\"sym_algorithm\">AES</property>\
-          <property name=\"encrypt_entire_message\">true</property>\
-          <property name=\"keystore_name\">${jg_encrypt_keystore_dir}/${jg_encrypt_keystore}</property>\
-          <property name=\"store_password\">${jg_encrypt_password}</property>\
-          <property name=\"alias\">${jg_encrypt_name}</property>\
-        </protocol>"
-    echo ${legacy_encrypt}
+    local legacy_encrypt
+    read -r -d '' legacy_encrypt <<- EOF
+      <protocol type="SYM_ENCRYPT">
+        <property name="provider">SunJCE</property>
+        <property name="sym_algorithm">AES</property>
+        <property name="encrypt_entire_message">true</property>
+        <property name="keystore_name">${jg_encrypt_keystore_dir}/${jg_encrypt_keystore}</property>
+        <property name="store_password">${jg_encrypt_password}</property>
+        <property name="alias">${jg_encrypt_name}</property>
+      </protocol>
+EOF
+
+    echo "${legacy_encrypt}"
 }
+
+create_jgroups_elytron_legacy_cli() {
+  declare jg_encrypt_keystore="$1" jg_encrypt_password="$2" jg_encrypt_name="$3" jg_encrypt_keystore_dir="$4"
+
+  local protocolTypes
+  local xpath
+  local result
+  local index
+  local protocolType
+  local config
+  local missingNAKACK2="false"
+  local stacks=(tcp udp)
+
+  for stack in "${stacks[@]}"; do
+    xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='stack' and @name='${stack}']/*[local-name()='protocol']/@type\""
+    testXpathExpression "${xpath}" "result" "protocolTypes"
+    index=0
+    if [ ${result} -eq 0 ]; then
+      protocolTypes=$(splitAttributesStringIntoLinks "${protocolTypes}" "type")
+      arr=(${protocolTypes})
+      
+      while read -r protocolType; do
+        if [ "${protocolType}" = "pbcast.NAKACK2" ]; then
+          break
+        fi
+        ((index=index+1))
+      done <<< "${protocolTypes}"
+     
+      if [ ${index} -eq ${#arr[@]} ]; then
+        echo "You have set JGROUPS_CLUSTER_PASSWORD environment variable to configure SYM_ENCRYPT protocol but pbcast.NAKACK2 protocol was not found for ${stack^^} stack. Fix your configuration to contain the pbcast.NAKACK2 in the JGroups subsystem for this to happen." >> "${CLI_SCRIPT_ERROR_FILE}"
+        missingNAKACK2="true"
+        continue
+      fi
+    fi
+
+    op=("/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT:add(add-index=${index})"
+        "/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT/property=provider:add(value=SunJCE)"
+        "/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT/property=sym_algorithm:add(value=AES)"
+        "/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT/property=encrypt_entire_message:add(value=true)"
+        "/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT/property=keystore_name:add(value=\"${jg_encrypt_keystore_dir}/${jg_encrypt_keystore}\")"
+        "/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT/property=store_password:add(value=\"${jg_encrypt_password}\")"
+        "/subsystem=jgroups/stack=$stack/protocol=SYM_ENCRYPT/property=alias:add(value=\"${jg_encrypt_name}\")"
+      )
+    config="${config} $(configure_protocol_cli_helper "${stack}" "SYM_ENCRYPT" "${op[@]}")"
+  done
+
+  if [ "${missingNAKACK2}" = "false" ]; then
+    echo "${config}"
+  fi
+}
+
 
 validate_keystore() {
     declare jg_encrypt_secret="$1" jg_encrypt_name="$2" jg_encrypt_password="$3" jg_encrypt_keystore="$4"
@@ -99,40 +236,97 @@ validate_keystore_legacy() {
       fi
 }
 
+validate_keystore_and_create() {
+  local mode="$1"
+
+  valid_state=$(validate_keystore "${JGROUPS_ENCRYPT_SECRET}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE}")
+
+  if [ "${valid_state}" = "valid" ]; then
+    if [ "${mode}" = "xml" ]; then
+      key_store=$(create_elytron_keystore "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      jgroups_encrypt=$(create_jgroups_elytron_encrypt_sym "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_ENTIRE_MESSAGE:-true}")
+    else
+      key_store=$(create_elytron_keystore_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      jgroups_encrypt=$(create_jgroups_elytron_encrypt_sym_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_ENTIRE_MESSAGE:-true}")
+    fi
+  fi
+}
+
+# used when elytron marker is not present
+validate_keystore_and_create_legacy() {
+  declare mode="$1"
+
+  valid_state=$(validate_keystore_legacy "${JGROUPS_ENCRYPT_SECRET}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+
+  if [ "${valid_state}" = "valid" ]; then
+    if [ "${mode}" = "xml" ]; then
+      jgroups_encrypt=$(create_jgroups_elytron_legacy "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+    else
+      jgroups_encrypt=$(create_jgroups_elytron_legacy_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+    fi
+  fi
+}
+
 configure_jgroups_encryption() {
+ local has_elytron_tls_marker=$(has_elytron_tls "${CONFIG_FILE}")
+ local has_elytron_keystore_marker=$(has_elytron_keystore "${CONFIG_FILE}")
+
+ if [ "${has_elytron_tls_marker}" = "true" ] || [ "${has_elytron_keystore_marker}" = "true" ]; then
+   # insert the new config element, only if it hasn't been added already
+   # basically it will transform the <!-- ##ELYTRON_TLS## --> into a divided sections separated by the following markers:
+   # <!-- ##ELYTRON_KEY_STORE## --> <!-- ##ELYTRON_KEY_MANAGER## --> <!-- ##ELYTRON_SERVER_SSL_CONTEXT## -->
+   # and will remove the old marker <!-- ##TLS## --> if exists.
+   # It also takes care of not to add twice the <!-- ##ELYTRON_KEY_STORE## --> marker, if it is already there, then <!-- ##ELYTRON_TLS## -->
+   # is not replaced.
+   # This change will allow the configuration of the KeyStore used by JGroups via Elytron integration
+   # instead of adding the keystore configuration at JGroups protocol level
+   insert_elytron_tls_config_if_needed "${CONFIG_FILE}"
+ fi
+
+ local encrypt_conf_mode
+ getConfigurationMode "<!-- ##JGROUPS_ENCRYPT## -->" "encrypt_conf_mode"
+
+ local key_store_conf_mode
+ getConfigurationMode "<!-- ##ELYTRON_KEY_STORE## -->" "key_store_conf_mode"
+
+ local has_elytron_subsystem
+ local xpath="\"//*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:wildfly:elytron:')]\""
+ testXpathExpression "${xpath}" "has_elytron_subsystem"
+
  local jgroups_encrypt_protocol="${JGROUPS_ENCRYPT_PROTOCOL:=SYM_ENCRYPT}"
  local jgroups_encrypt=""
  local key_store=""
+
  case "${jgroups_encrypt_protocol}" in
   "SYM_ENCRYPT")
     log_info "Configuring JGroups cluster traffic encryption protocol to SYM_ENCRYPT."
     local jgroups_unencrypted_message="Detected <STATE> JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted."
-    local keystore_warning_message=""
-    local has_elytron_tls_marker=$(has_elytron_tls "${CONFIG_FILE}")
-    local keystore_validation_state="";
-    if [ "${has_elytron_tls_marker}" = "true" ]; then
-        keystore_validation_state=$(validate_keystore "${JGROUPS_ENCRYPT_SECRET}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE}")
+    local valid_state=""
+
+    if [ "${has_elytron_subsystem}" -eq 0 ]; then
+      if [ "${key_store_conf_mode}" = "xml" ]; then
+        validate_keystore_and_create "xml"
+      elif [ "${key_store_conf_mode}" = "cli" ]; then
+        validate_keystore_and_create "cli"
+        
+        # This if-check is here to cover the following case: User has strictly defined that he wants only replacement via xml markers (CONFIG_ADJUSTMENT_MODE=xml), 
+        # we have the Elytron subsystem but we do not have the Keystore marker, in that case, then replace the protocol using the "legacy" style, 
+        # which means include the key store in the JGroups protocol itself.
+      elif [ "${CONFIG_ADJUSTMENT_MODE,,}" = "xml" ]; then
+        validate_keystore_and_create_legacy "xml"
+      fi
     else
-        keystore_validation_state=$(validate_keystore_legacy "${JGROUPS_ENCRYPT_SECRET}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      if [ "${key_store_conf_mode}" = "xml" ]; then
+        validate_keystore_and_create_legacy "xml"
+      elif [ "${key_store_conf_mode}" = "cli" ]; then
+        validate_keystore_and_create_legacy "cli"
+      fi
     fi
 
-    if [ "${keystore_validation_state}" = "valid" ]; then
-        # first add the elytron key-store:
-        if [ "${has_elytron_tls_marker}" = "true" ]; then
-            key_store=$(create_elytron_keystore "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
-            jgroups_encrypt=$(create_jgroups_elytron_encrypt_sym "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_ENTIRE_MESSAGE:-true}")
-        else
-            # compatibility with old marker, only used if new marker is not present
-            jgroups_encrypt=$(create_jgroups_elytron_legacy "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
-        fi
-    elif [ "${keystore_validation_state}" = "partial" ]; then
-        keystore_warning_message="${jgroups_unencrypted_message//<STATE>/partial}"
-    else
-         keystore_warning_message="${jgroups_unencrypted_message//<STATE>/missing}"
-    fi
-
-    if [ -n "${keystore_warning_message}" ]; then
-        log_warning "${keystore_warning_message}"
+    if [ "${valid_state}" = "partial" ]; then
+        log_warning "${jgroups_unencrypted_message//<STATE>/partial}"
+    elif [ "${valid_state}" = "missing" ]; then
+        log_warning "${jgroups_unencrypted_message//<STATE>/missing}"
     fi
   ;;
   "ASYM_ENCRYPT")
@@ -147,22 +341,26 @@ configure_jgroups_encryption() {
 
       # CLOUD-2437 AUTH protocol is required when using ASYM_ENCRYPT protocol: https://github.com/belaban/JGroups/blob/master/conf/asym-encrypt.xml#L23
       if [ -n "${JGROUPS_CLUSTER_PASSWORD}" ]; then
-        jgroups_encrypt=$(create_jgroups_encrypt_asym)
+        if [ "${encrypt_conf_mode}" = "xml" ]; then
+          jgroups_encrypt=$(create_jgroups_encrypt_asym)
+        elif [ "${encrypt_conf_mode}" = "cli" ]; then
+          jgroups_encrypt=$(create_jgroups_encrypt_asym_cli)
+        fi
       else
         log_warning "JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT requires JGROUPS_CLUSTER_PASSWORD to be set and not empty, the communication within the cluster WILL NOT be encrypted."
       fi
     ;;
   esac
 
-
-  if [ "$(has_elytron_tls "${CONFIG_FILE}")" = "true" ] || [ "$(has_elytron_keystore "${CONFIG_FILE}")" = "true" ]; then
-    # insert the new config element, only if it hasn't been added already
-    insert_elytron_tls_config_if_needed "${CONFIG_FILE}"
-    # note we leave the <!-- ##ELYTRON_KEY_STORE## --> tag in case something else needs to add a keystore etc.
+  if [ "${key_store_conf_mode}" = "xml" ]; then
     sed -i "s|<!-- ##ELYTRON_KEY_STORE## -->|${key_store}<!-- ##ELYTRON_KEY_STORE## -->|" $CONFIG_FILE
+  elif [ "${key_store_conf_mode}" = "cli" ]; then
+    echo "${key_store}" >> ${CLI_SCRIPT_FILE}
   fi
-
-  # this will either substitute in the new config, or the legacy one, depending on how we were configured above.
-  sed -i "s|<!-- ##JGROUPS_ENCRYPT## -->|${jgroups_encrypt}|g" "$CONFIG_FILE"
-
+  
+  if [ "${encrypt_conf_mode}" = "xml" ]; then
+    sed -i "s|<!-- ##JGROUPS_ENCRYPT## -->|${jgroups_encrypt}|g" "$CONFIG_FILE"
+  elif [ "${encrypt_conf_mode}" = "cli" ]; then
+    echo "${jgroups_encrypt}" >> ${CLI_SCRIPT_FILE}
+  fi
 }

--- a/jboss/container/wildfly/launch/jgroups/added/launch/jgroups_common.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/jgroups_common.sh
@@ -1,0 +1,37 @@
+configure_protocol_cli_helper() {
+  local params=("${@}")
+  local stack=${params[0]}
+  local protocol=${params[1]}
+  local result
+  IFS= read -rd '' result <<- EOF
+    
+    if (outcome != success) of /subsystem=jgroups/stack=${stack}:read-resource
+        /subsystem=jgroups/stack=${stack}:add()
+    end-if
+
+    if (outcome == success) of /subsystem=jgroups/stack="${stack}"/protocol="${protocol}":read-resource
+        echo Cannot configure jgroups '${protocol}' protocol under '${stack}' stack. This protocol is already configured. >> \${error_file}
+        quit
+    end-if
+
+    if (outcome != success) of /subsystem=jgroups/stack="${stack}"/protocol="${protocol}":read-resource
+        batch
+EOF
+  # removes the latest new line added by read builtin command
+  result=$(echo -n "${result}")
+
+  # starts in 2, since 0 and 1 are arguments
+  for ((j=2; j<${#params[@]}; ++j)); do
+    result="${result}
+            ${params[j]}"
+  done
+
+  IFS= read -r -d '' result <<- EOF
+        ${result}
+       run-batch
+    end-if
+EOF
+
+
+  echo "${result}"
+}

--- a/jboss/container/wildfly/launch/jgroups/module.yaml
+++ b/jboss/container/wildfly/launch/jgroups/module.yaml
@@ -11,3 +11,28 @@ modules:
 execute:
 - script: configure.sh
   user: '185'
+envs:
+  - name: "JGROUPS_CLUSTER_PASSWORD"
+    example: "p@ssw0rd"
+    description: Password used to authenticate the node so it is allowed to join the JGroups cluster. Required, when using ASYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, authentication is disabled, cluster communication is not encrypted and a warning is issued. Optional, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol.
+  - name: "JGROUPS_ENCRYPT_KEYSTORE"
+    example: "jgroups.jceks"
+    description: Name of the keystore file within the secret specified via JGROUPS_ENCRYPT_SECRET variable, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, cluster communication is not encrypted and a warning is issued.
+  - name: "JGROUPS_ENCRYPT_KEYSTORE_DIR"
+    example: "/etc/jgroups-encrypt-secret-volume"
+    description: Directory path of the keystore file within the secret specified via JGROUPS_ENCRYPT_SECRET variable, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, cluster communication is not encrypted and a warning is issued.
+  - name: "JGROUPS_ENCRYPT_NAME"
+    example: "jgroups"
+    description: Name associated with the server’s certificate, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, cluster communication is not encrypted and a warning is issued.
+  - name: "JGROUPS_ENCRYPT_PASSWORD"
+    example: "p@ssw0rd"
+    description: Password used to access the keystore and the certificate, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, cluster communication is not encrypted and a warning is issued.
+  - name: "JGROUPS_ENCRYPT_PROTOCOL"
+    example: "SYM_ENCRYPT"
+    description: JGroups protocol to use for encryption of cluster traffic. Can be either SYM_ENCRYPT or ASYM_ENCRYPT. Defaults to SYM_ENCRYPT.
+  - name: "JGROUPS_ENCRYPT_SECRET"
+    example: "app-secret"
+    description: Name of the secret, containing the JGroups keystore file used for securing the JGroups communications, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, cluster communication is not encrypted and a warning is issued.
+  - name: "JGROUPS_PING_PROTOCOL"
+    example: "openshift.DNS_PING"
+    description: JGroups protocol to use for node discovery. Can be either openshift.DNS_PING or kubernetes.KUBE_PING. 

--- a/jboss/container/wildfly/launch/jgroups/test/server-configs/standalone-openshift-jgroups.xml
+++ b/jboss/container/wildfly/launch/jgroups/test/server-configs/standalone-openshift-jgroups.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:5.0">
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jgroups:5.0">
+            <channels default="ee">
+                <channel name="ee" stack="tcp"/>
+            </channels>
+            <stacks>
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                </stack>
+                <stack name="tcp">
+                    <protocol type="pbcast.NAKACK2"/>
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+            </stacks>
+        </subsystem>
+    </profile>
+</server>

--- a/jboss/container/wildfly/launch/jgroups/test/server-configs/standalone-openshift-pbcast.NAKACK2.xml
+++ b/jboss/container/wildfly/launch/jgroups/test/server-configs/standalone-openshift-pbcast.NAKACK2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:5.0">
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jgroups:5.0">
+            <channels default="ee">
+                <channel name="ee" stack="tcp"/>
+            </channels>
+            <stacks>
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+                <stack name="tcp">
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+            </stacks>
+        </subsystem>
+    </profile>
+</server>

--- a/jboss/container/wildfly/launch/jgroups/test/server-configs/standalone-openshift-with-elytron.xml
+++ b/jboss/container/wildfly/launch/jgroups/test/server-configs/standalone-openshift-with-elytron.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:5.0">
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jgroups:5.0">
+            <channels default="ee">
+                <channel name="ee" stack="tcp"/>
+            </channels>
+            <stacks>
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+                <stack name="tcp">
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+            </stacks>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:1.2" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+        </subsystem>
+    </profile>
+</server>


### PR DESCRIPTION
Enable JGroups encryption via CLI operations. Behave and bats tets passing.

It requires: https://github.com/wildfly/temp-eap-modules/pull/42