### PR TITLE
Do not use legacy realm when elytron used

### DIFF
--- a/jboss/container/wildfly/launch/admin/added/launch/admin.sh
+++ b/jboss/container/wildfly/launch/admin/added/launch/admin.sh
@@ -41,8 +41,9 @@ function configure_administration() {
         echo You have set environment variables to configure http-interface security-realm. Fix your configuration to contain the http-interface for this to happen. >> \${error_file}
         exit
       end-if
-
-      /core-service=management/management-interface=http-interface:write-attribute(name=security-realm, value=ManagementRealm)
+      if (result == undefined) of /core-service=management/management-interface=http-interface:read-attribute(name=http-authentication-factory)
+        /core-service=management/management-interface=http-interface:write-attribute(name=security-realm, value=ManagementRealm)
+      end-if
 EOF
     fi
   fi

--- a/jboss/container/wildfly/launch/mp-config/added/launch/mp-config.sh
+++ b/jboss/container/wildfly/launch/mp-config/added/launch/mp-config.sh
@@ -25,7 +25,7 @@ configure_microprofile_config_source() {
       #expected to fail if config-map is already configured
       cat << EOF >> ${CLI_SCRIPT_FILE}
       if (outcome != success) of /subsystem=microprofile-config-smallrye:read-resource
-          echo \"Cannot configure Microprofile Config. MICROPROFILE_CONFIG_DIR was specified but the subsystem in not in the server configuration.\" >> \${error_file}
+          echo \"You have set MICROPROFILE_CONFIG_DIR to configure a config-source. Fix your configuration to contain the microprofile-config subsystem for this to happen.\" >> \${error_file}
           quit
       end-if
 


### PR DESCRIPTION
admin.sh: Although security-realm is ignored when http-factory is set, it is cleaner to not set it.
mp-config.sh: Modified error message