### PR TITLE
Append to file to allow catching all configuration when the function is executed more than once

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -106,7 +106,7 @@ function configure_drivers(){
         if [ "${configMode}" = "xml" ]; then
           sed -i "s|<!-- ##DRIVERS## -->|${drivers}<!-- ##DRIVERS## -->|" $CONFIG_FILE
         elif [ "${configMode}" = "cli" ]; then
-          echo "${drivers}" > ${S2I_CLI_DRIVERS_FILE}
+          echo "${drivers}" >> ${S2I_CLI_DRIVERS_FILE}
           if [ "${CONFIG_ADJUSTMENT_MODE,,}" = "cli" ]; then
             exec_cli_scripts "${S2I_CLI_DRIVERS_FILE}"
           fi


### PR DESCRIPTION
https://issues.jboss.org/browse/WFWIP-214

Simply replace the file redirection with append to the file so that configuration of all drivers is saved in drivers.cli