### PR TITLE
Fix for WFWIP-214, append to CLI script file

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -106,9 +106,13 @@ function configure_drivers(){
         if [ "${configMode}" = "xml" ]; then
           sed -i "s|<!-- ##DRIVERS## -->|${drivers}<!-- ##DRIVERS## -->|" $CONFIG_FILE
         elif [ "${configMode}" = "cli" ]; then
-          echo "${drivers}" > ${S2I_CLI_DRIVERS_FILE}
           if [ "${CONFIG_ADJUSTMENT_MODE,,}" = "cli" ]; then
+            # CLI execution to add current driver(s)
+            echo "${drivers}" > ${S2I_CLI_DRIVERS_FILE}
             exec_cli_scripts "${S2I_CLI_DRIVERS_FILE}"
+          else
+            # append to CLI script for delayed CLI execution at server launch
+            echo "${drivers}" >> ${S2I_CLI_DRIVERS_FILE}
           fi
         fi
       fi


### PR DESCRIPTION
https://issues.jboss.org/browse/WFWIP-214

- For pure cli execution, the driver content is not appended and script is executed
- For xml_cli, the driver content is appended and script execution is delayed at launch time.

An alternative of calling multiple time configure_drivers is by adding multiple prefixes to the DRIVERS env var.

This PR replaces: https://github.com/wildfly/wildfly-cekit-modules/pull/92