### PR TITLE
adjust base layers to WF 18

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/base-layers/added/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
+++ b/jboss/container/wildfly/galleon/fp-content/base-layers/added/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
@@ -4,5 +4,6 @@
         <layer name="cloud-profile"/>
         <layer name="core-server"/>
     </dependencies>
+    <feature-group name="undertow-elytron-security"/>
 </layer-spec>
 

--- a/jboss/container/wildfly/galleon/fp-content/base-layers/added/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
+++ b/jboss/container/wildfly/galleon/fp-content/base-layers/added/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
@@ -5,5 +5,6 @@
         <layer name="core-server"/>
         <layer name="datasources" optional="true"/>
     </dependencies>
+    <feature-group name="undertow-elytron-security"/>
 </layer-spec>
 


### PR DESCRIPTION
* Adjust for WF18, to merge only when WF 18 is released and WildFly s2i image is based on it.