### PR TITLE
[WFWIP-212] Always use echo for the embedded server output

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
@@ -99,7 +99,7 @@ function processErrorsAndWarnings() {
 
 function exec_cli_scripts() {
   local script="$1"
-  local stdOut="discard"
+  local stdOut="echo"
 
   if [ "${SCRIPT_DEBUG}" = "true" ]; then
     CLI_DEBUG="TRUE";
@@ -114,7 +114,6 @@ function exec_cli_scripts() {
 
     # Dump the cli script file for debugging
     if [ "${CLI_DEBUG^^}" = "TRUE" ]; then
-      stdOut="echo"
 
       echo "================= CLI files debug ================="
       if [ -f "${script}" ]; then


### PR DESCRIPTION
By default, use 'echo' to get all the embedded server output which will be printed if an error is found here: https://github.com/yersan/wildfly-cekit-modules/blob/94ea07c886ce8e9dde4e152a9e19f19609eba650/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh#L160

Jira issue: https://issues.jboss.org/browse/WFWIP-212