### PR TITLE
Fix for WFWIP-221, jps can't see server process in Openshift

### DIFF
--- a/jboss/container/wildfly/galleon/provision-server/configure.sh
+++ b/jboss/container/wildfly/galleon/provision-server/configure.sh
@@ -33,3 +33,6 @@ rm -r $TARGET_DIR
 chown -R jboss:root $JBOSS_HOME && chmod -R ug+rwX $JBOSS_HOME 
 chown -R jboss:root $HOME
 chmod -R ug+rwX $GALLEON_LOCAL_MAVEN_REPO
+
+# Remove java tmp perf data dir owned by 185
+rm -rf /tmp/hsperfdata_jboss


### PR DESCRIPTION
Deleting /tmp/hsperfdata_jboss created when using maven to provision server.