### PR TITLE
[WFWIP-226] Fix wrong properties for JGroups ASYM_ENCRYPT protocol

### DIFF
--- a/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
@@ -153,7 +153,8 @@ create_jgroups_encrypt_asym_cli() {
             "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=sym_keylength:add(value=\"${sym_keylength:-128}\")"
             "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=sym_algorithm:add(value=\"${sym_algorithm:-AES/ECB/PKCS5Padding}\")"
             "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=asym_keylength:add(value=\"${asym_keylength:-512}\")"
-            "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value=\"${change_key_on_leave:-true}\")"
+            "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value=\"${asym_algorithm:-RSA}\")"
+            "/subsystem=jgroups/stack=$stack/protocol=ASYM_ENCRYPT/property=change_key_on_leave:add(value=\"${change_key_on_leave:-true}\")"
         )
         config="${config} $(configure_protocol_cli_helper "${stack}" "ASYM_ENCRYPT" "${op[@]}")"
       done  <<< "${stackNames}"

--- a/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
+++ b/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
@@ -323,7 +323,8 @@ normalize_spaces_new_lines() {
                /subsystem=jgroups/stack=udp/protocol=ASYM_ENCRYPT/property=sym_keylength:add(value="128")
                /subsystem=jgroups/stack=udp/protocol=ASYM_ENCRYPT/property=sym_algorithm:add(value="AES/ECB/PKCS5Padding")
                /subsystem=jgroups/stack=udp/protocol=ASYM_ENCRYPT/property=asym_keylength:add(value="512")
-               /subsystem=jgroups/stack=udp/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value="true")
+               /subsystem=jgroups/stack=udp/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value="RSA")
+               /subsystem=jgroups/stack=udp/protocol=ASYM_ENCRYPT/property=change_key_on_leave:add(value="true")
           run-batch
        end-if
 
@@ -338,7 +339,8 @@ normalize_spaces_new_lines() {
                /subsystem=jgroups/stack=tcp/protocol=ASYM_ENCRYPT/property=sym_keylength:add(value="128")
                /subsystem=jgroups/stack=tcp/protocol=ASYM_ENCRYPT/property=sym_algorithm:add(value="AES/ECB/PKCS5Padding")
                /subsystem=jgroups/stack=tcp/protocol=ASYM_ENCRYPT/property=asym_keylength:add(value="512")
-               /subsystem=jgroups/stack=tcp/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value="true")
+               /subsystem=jgroups/stack=tcp/protocol=ASYM_ENCRYPT/property=asym_algorithm:add(value="RSA")
+               /subsystem=jgroups/stack=tcp/protocol=ASYM_ENCRYPT/property=change_key_on_leave:add(value="true")
           run-batch
        end-if
 EOF


### PR DESCRIPTION
These ops https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh#L152 should be equivalent to https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh#L100

Jira issue:https://issues.jboss.org/browse/WFWIP-226