### PR TITLE
Fix empty default connection factory

### DIFF
--- a/jboss/container/wildfly/launch/messaging/added/launch/messaging.sh
+++ b/jboss/container/wildfly/launch/messaging/added/launch/messaging.sh
@@ -937,7 +937,7 @@ EOF
         sed -i "s|##DEFAULT_JMS##||" $CONFIG_FILE
       fi
     elif [ "${default_jms_config_mode}" = "cli" ]; then
-      if [ "$REMOTE_AMQ_BROKER" = "true" ] || ([ -n "${MQ_QUEUES}" ] || [ -n "${HORNETQ_QUEUES}" ] || [ -n "${MQ_TOPICS}" ] || [ -n "${HORNETQ_TOPICS}" ] || [ "x${DISABLE_EMBEDDED_JMS_BROKER}" != "xtrue" ]) && [ "x${DISABLE_EMBEDDED_JMS_BROKER}" != "xalways" ]; then
+      if ([ "$REMOTE_AMQ_BROKER" = "true" ] || ([ -n "${MQ_QUEUES}" ] || [ -n "${HORNETQ_QUEUES}" ] || [ -n "${MQ_TOPICS}" ] || [ -n "${HORNETQ_TOPICS}" ] || [ "x${DISABLE_EMBEDDED_JMS_BROKER}" != "xtrue" ]) && [ "x${DISABLE_EMBEDDED_JMS_BROKER}" != "xalways" ]) && [ -n "${defaultJmsConnectionFactoryJndi}" ]; then
         echo "/subsystem=ee/service=default-bindings:write-attribute(name=jms-connection-factory, value=\"${defaultJmsConnectionFactoryJndi}\")" >> "${CLI_SCRIPT_FILE}"
       else
         echo "/subsystem=ee/service=default-bindings:undefine-attribute(name=jms-connection-factory)" >> "${CLI_SCRIPT_FILE}"


### PR DESCRIPTION
In case of a warning message, for example, missing _SERVICE_HOST / _SERVICE_PROTOCOL, the embedded server tries to configure an empty default connection factory failing in that case.

