### PR TITLE
Add the list of Jaeger environment properties that can be used to configure Tracing

### DIFF
--- a/jboss/container/wildfly/launch/tracing/module.yaml
+++ b/jboss/container/wildfly/launch/tracing/module.yaml
@@ -2,9 +2,11 @@ schema_version: 1
 name: jboss.container.wildfly.launch.tracing
 version: '1.0'
 description: OpenTracing configuration scripts
+
 execute:
 - script: configure.sh
   user: '185'
+
 envs:
     - name: "WILDFLY_TRACING_ENABLED"
       example: "true"
@@ -15,3 +17,29 @@ envs:
     - name: "JAEGER_AGENT_PORT"
       example: "6831"
       description: "The port to use for communicating with a Jaeger agent via UDP. Default is '6831'."
+    - name: "JAEGER_SERVICE_NAME"
+      description: "The service name"
+    - name: "JAEGER_ENDPOINT"
+      description: "The traces endpoint, in case the client should connect directly to the Collector, like http://jaeger-collector:14268/api/traces"
+    - name: "JAEGER_AUTH_TOKEN"
+      description: "Authentication Token to send as 'Bearer' to the endpoint"
+    - name: "JAEGER_USER"
+      description: "Username to send as part of 'Basic' authentication to the endpoint"
+    - name: "JAEGER_PASSWORD"
+      description: "Password to send as part of 'Basic' authentication to the endpoint"
+    - name: "JAEGER_PROPAGATION"
+      description: "Comma separated list of formats to use for propagating the trace context. Defaults to the standard Jaeger format. Valid values are jaeger and b3"
+    - name: "JAEGER_REPORTER_LOG_SPANS"
+      description: "Whether the reporter should also log the spans"
+    - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+      description: "The reporter's maximum queue size"
+    - name: "JAEGER_REPORTER_FLUSH_INTERVAL"
+      description: "The reporter's flush interval (ms)"
+    - name: "JAEGER_SAMPLER_TYPE"
+      description: "The sampler type"
+    - name: "JAEGER_SAMPLER_PARAM"
+      description: "The sampler parameter (number)"
+    - name: "JAEGER_SAMPLER_MANAGER_HOST_PORT"
+      description: "The host name and port when using the remote controlled sampler"
+    - name: "JAEGER_TAGS"
+      description: "A comma separated list of name = value tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format ${envVarName:default}, where the :default is optional, and identifies a value to be used if the environment variable cannot be found"


### PR DESCRIPTION
Added documentation of missing additional environment variables that can be used to configure Tracing

They have been taken from https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-core