### PR TITLE
add ability to specify a class for a stale connection

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -457,6 +457,14 @@ function generate_external_datasource_xml() {
                            <background-validation-millis>${millis}</background-validation-millis>"
     fi
 
+
+    # allows for specificaiton of a stale-connection-checker
+    stale_checker=$(find_env "${prefix}_STALE_CONNECTION_CHECKER")
+    if [ -n $stale_checker ]; then
+        validation_conf="$validation_conf
+                           <stale-connection-checker class-name=\"${stale_checker}\"/>"
+    fi
+
     ds="$ds
            <validation>
              ${validation_conf}


### PR DESCRIPTION
for example - want the resulting datasource validations to look like - 

```
<validation>
        <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker"/>
        <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker"/>
        <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter"/>
    </validation>
```