### PR TITLE
[CLOUD-3440] Redirect dynamic_resources.sh standard output to null when sourcing in standalone.conf

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
+++ b/jboss/container/wildfly/galleon/fp-content/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
@@ -1,5 +1,5 @@
 
-source /usr/local/dynamic-resources/dynamic_resources.sh
+source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
 export GC_METASPACE_SIZE=${GC_METASPACE_SIZE:-96}
 export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
 


### PR DESCRIPTION
When java-default-options is sourced by any script to make use of its functions, by default prints to the standard output the calculated [JAVA_OPTS](https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options#L172)

We cannot remove this echo, because it can be used by other parties to get the calculated values when sourcing it, so a workaround to avoid print this message when the server start could be to redirect to null the output when we are sourcing it in the standalone.conf file.

Jira issue: https://issues.jboss.org/browse/CLOUD-3440