### PR TITLE
[CLOUD-3441] Duration of server configuration is not printed

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
@@ -151,7 +151,7 @@ function exec_cli_scripts() {
       cat "${CLI_SCRIPT_OUTPUT_FILE}"
     fi
 
-    log_info "Duration: " $((end-start)) " milliseconds"
+    log_info "Duration: $((end-start)) milliseconds"
 
     if [ $cli_result -ne 0 ]; then
       log_error "Error applying ${CLI_SCRIPT_FILE_FOR_EMBEDDED} CLI script."


### PR DESCRIPTION
log_info expects just one argument which is the message to print in the standard output.

Jira issue: https://issues.jboss.org/browse/CLOUD-3441