### PR TITLE
[CLOUD-3448] typo fix: clearing the correct datasource environmental variables

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -31,8 +31,8 @@ function clearDatasourceEnv() {
   local prefix=$1
   local service=$2
 
-  unset ${service}_HOST
-  unset ${service}_PORT
+  unset ${service}_SERVICE_HOST
+  unset ${service}_SERVICE_PORT
   unset ${prefix}_JNDI
   unset ${prefix}_USERNAME
   unset ${prefix}_PASSWORD


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3448

@luck3y @kabir please, take a look