### PR TITLE
[CLOUD-3451] the default for JTA is true not false

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -954,7 +954,7 @@ function inject_datasource() {
 
   if [ -z "$jta" ]; then
     log_warning "JTA flag not set, defaulting to true for datasource  ${service_name}"
-    jta=false
+    jta=true
   fi
 
   if [ -z "$driver" ]; then


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3451

The default value for JTA attribute is true (based on the prior behaviour and the documentation)