### PR TITLE
[CLOUD-3188] Move GC logs to PREPEND_JAVA_OPTS to bypass the specific EAP checks

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
+++ b/jboss/container/wildfly/galleon/fp-content/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
@@ -5,6 +5,14 @@ export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
 
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 
+# If JAVA_DIAGNOSTICS and there is jvm_specific_diagnostics, move the settings to PREPEND_JAVA_OPTS
+# to bypass the specific EAP checks done on JAVA_OPTS in standalone.sh that could remove the GC EAP specific log configurations
+JVM_SPECIFIC_DIAGNOSTICS=$(jvm_specific_diagnostics)
+if [ "x$JAVA_DIAGNOSTICS" != "x" ] && [ "x{JVM_SPECIFIC_DIAGNOSTICS}" != "x" ]; then
+  JAVA_OPTS=${JAVA_OPTS/${JVM_SPECIFIC_DIAGNOSTICS} /}
+  PREPEND_JAVA_OPTS="${JVM_SPECIFIC_DIAGNOSTICS} ${PREPEND_JAVA_OPTS}"
+fi
+
 # Make sure that we use /dev/urandom (CLOUD-422)
 JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom"
 


### PR DESCRIPTION
The solution is a bit hacky, but I haven't found a better approach, so maybe this one is acceptable.

EAP in standalone.sh will avoid adding any GC log file configuration if there is any JAVA_OPTS setting related to GC logs. This check clashes with the jvm_specific_diagnostics for JDK 11, where the -`Xlog:gc::utctime` decorator is enabled.

To prevent EAP skips the GC log file configuration due to the jvm_specific_diagnostics settings, we could remove the settings from the JAVA_OPTS and add them to PREPEND_JAVA_OPTS. That change will bypass the EAP specific checks.

jira issue: https://issues.redhat.com/browse/CLOUD-3188