### PR TITLE
[issue-147] Allows override install-common.sh functions from wildfly-s2i

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -120,3 +120,6 @@ function configure_drivers(){
   )
 }
 
+if [ -s /usr/local/s2i/install-common-overrides.sh ]; then
+  source /usr/local/s2i/install-common-overrides.sh
+fi


### PR DESCRIPTION
This PR follows up https://github.com/wildfly/wildfly-cekit-modules/pull/159 since it depends on it to avoid see an error when then the embedded server is used during S2I phase.

This patch allows overriding install-common.sh functions from wildfly-s2i by using /usr/local/s2i/install-common-overrides.sh