### PR TITLE
Fix for CLOUD-3505, Provisioned server is not deleted once installed

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
@@ -235,6 +235,7 @@ function galleon_provision_server() {
           targetDir=$GALLEON_DESCRIPTION_LOCATION/target/server
           if [ -d $targetDir ]; then
             galleon_replace_server $targetDir
+            rm -rf $targetDir
           else
             echo "Error, no server provisioned in $targetDir"
             exit 1


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3505 Fix for 0.18.x branch
The provisioned server is deleted from the target directory.