### PR TITLE
Adapt jpa-distributed layer to openshift context

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
+++ b/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa-distributed">
+    <exclude spec="subsystem.jgroups.channel"/>
+    <feature spec="subsystem.jgroups.channel">
+        <param name="channel" value="ee"/>
+        <param name="stack" value="tcp"/>
+        <unset param="cluster"/>
+    </feature>
+    
+    <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK">
+        <param name="stack" value="udp"/>
+        <unset param="socket-binding"/>
+    </feature>
+    <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK">
+        <param name="stack" value="tcp"/>
+        <unset param="socket-binding"/>
+    </feature>
+    <exclude feature-id="subsystem.jgroups.stack.protocol:stack=udp,protocol=PING"/>
+    <exclude feature-id="subsystem.jgroups.stack.protocol.MPING:stack=tcp"/>
+    
+    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-udp-fd"/>
+    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-tcp-fd"/>
+    
+    <feature-group name="os-infinispan-hibernate"/>
+
+</layer-spec>


### PR DESCRIPTION
jpa-distributed is a new layer in WF19 beta3 that needs to be adjusted (jgroups and infinispan).
