### PR TITLE
[0.18.x] ]Fix for CLOUD-3516, Avoid copying JBOSS_HOME content during s2i

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
@@ -9,6 +9,10 @@ function copy_server_s2i_output() {
       mkdir -p $WILDFLY_S2I_OUTPUT_DIR
       log_info "Copying server to $WILDFLY_S2I_OUTPUT_DIR"
       cp -r -L $JBOSS_HOME $WILDFLY_S2I_OUTPUT_DIR/server
+      rm -rf $JBOSS_HOME
+      rm -rf /deployments/*
+      log_info "Linking $JBOSS_HOME to $WILDFLY_S2I_OUTPUT_DIR"
+      ln -s $WILDFLY_S2I_OUTPUT_DIR/server $JBOSS_HOME
     fi
   else
     if [ "x$S2I_COPY_SERVER" == "xtrue" ]; then


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3516
In the build-artifacts image, in case a fat server has been provisioned (Galleon), JBOSS_HOME becomes a link to /s2i-output/server.