### PR TITLE
[CLOUD-3537] Remove the requirement for adding the log manager and it…

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/jolokia/added/src/main/resources/packages/wildfly.s2i.jolokia/content/bin/jolokia-conf.conf
+++ b/jboss/container/wildfly/galleon/fp-content/jolokia/added/src/main/resources/packages/wildfly.s2i.jolokia/content/bin/jolokia-conf.conf
@@ -1,53 +1,9 @@
 
-. $JBOSS_HOME/bin/launch/files.sh
-
-JBOSS_MODULES_JAR=$(getfiles jboss-modules)
-JBOSS_LOGMANAGER_JAR=$(getfiles org/jboss/logmanager/main/jboss-logmanager)
-WILDFLY_COMMON_JAR=$(getfiles org/wildfly/common/main/wildfly-common)
-
-# for newer WF, these modules have changed names. We try the old ones first
-# then the new ones for compatability
-
-JBOSS_JSON_JAR=$(getfiles org/wildfly/javax/json/main/javax.json-1)
-if [ $? -ne "0" ]; then
-    JBOSS_JSON_JAR=$(getfiles org/glassfish/javax/json/main/javax.json-1)
-    if [ $? -ne "0" ]; then
-      JBOSS_JSON_JAR=$(getfiles org/glassfish/jakarta/json/main/jakarta.json-1)
-    fi
-fi
-
-if [ $? -ne "0" ]; then
-    echo Unable to locate a javax.json JAR, aborting.
-    exit 1
-fi
-
-JBOSS_JSON_API_JAR=$(getfiles org/wildfly/javax/json/main/javax.json-api)
-if [ $? -ne "0" ]; then
-    JBOSS_JSON_API_JAR=$(getfiles javax/json/api/main/javax.json-api)
-    if [ $? -ne "0" ]; then
-      JBOSS_JSON_API_JAR=$(getfiles javax/json/api/main/jakarta.json-api)
-    fi
-fi
-
-if [ $? -ne "0" ]; then
-    echo Unable to locate a javax.json API JAR, aborting.
-    exit 1
-fi
-
 AB_JOLOKIA_PORT=$((${AB_JOLOKIA_PORT:-8778} + ${PORT_OFFSET:-0}))
 export AB_JOLOKIA_PORT
 
 # add jolokia options
-JAVA_OPTS="${JAVA_OPTS} $(/opt/jolokia/jolokia-opts)"
+MODULE_OPTS="${MODULE_OPTS} $(/opt/jolokia/jolokia-opts)"
 
 IFS=. read -r -a java_version <<< "${JAVA_VERSION}"
 java_maj_version=${java_version[0]:-8}
-
-# default to 11, but this could be >= 9?
-if [ ${java_maj_version} -ge 11 ]; then
-    JAVA_OPTS="$JAVA_OPTS -Xbootclasspath/a:${JBOSS_LOGMANAGER_JAR}:${JBOSS_JSON_JAR}:${JBOSS_JSON_API_JAR}:${WILDFLY_COMMON_JAR}"
-else
-    # note this is intended as a conservative default to apply to JDK 8 & EAP 7.2, and provide the old behavior for images not using JDK11
-    JAVA_OPTS="$JAVA_OPTS -Xbootclasspath/p:${JBOSS_MODULES_JAR}:${JBOSS_LOGMANAGER_JAR}:${JBOSS_JSON_JAR}:${JBOSS_JSON_API_JAR}:${WILDFLY_COMMON_JAR}"
-fi
-JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dsun.util.logging.disableCallerCheck=true"

--- a/jboss/container/wildfly/launch-config/os/added/launch/jboss_modules_system_pkgs.sh
+++ b/jboss/container/wildfly/launch-config/os/added/launch/jboss_modules_system_pkgs.sh
@@ -10,7 +10,7 @@ function configure() {
 
 function configure_jboss_modules_system_pkgs() {
   if [ -z "$JBOSS_MODULES_SYSTEM_PKGS" ]; then
-    export JBOSS_MODULES_SYSTEM_PKGS="org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider"
+    export JBOSS_MODULES_SYSTEM_PKGS="jdk.nashorn.api,com.sun.crypto.provider"
   fi
 
   if [ -n "$JBOSS_MODULES_SYSTEM_PKGS_APPEND" ]; then

--- a/jboss/container/wildfly/launch-config/os/module.yaml
+++ b/jboss/container/wildfly/launch-config/os/module.yaml
@@ -8,7 +8,7 @@ envs:
   example: "org.jboss.byteman"
   description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
 - name: "JBOSS_MODULES_SYSTEM_PKGS"
-  value: "org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider"
+  value: "jdk.nashorn.api,com.sun.crypto.provider"
 execute:
 - script: configure.sh
   user: '185'


### PR DESCRIPTION
…'s dependencies to the boot class path. This will be fixed via WFCORE-4748.

https://issues.redhat.com/browse/CLOUD-3537

This will not work until [WFCORE-4674](https://issues.redhat.com/browse/WFCORE-4674) is resolved and WildFly 21 is released. If this shouldn't remain in the queue until then please feel free to close this.