### PR TITLE
[JBEAP-18124] non-xa datasource should be configured with txn isolati…

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -393,11 +393,11 @@ function generate_external_datasource_xml() {
       ds="$ds
              <driver>${driver}</driver>"
     fi
+  fi
 
-    if [ -n "$tx_isolation" ]; then
-      ds="$ds
+  if [ -n "$tx_isolation" ]; then
+    ds="$ds
              <transaction-isolation>$tx_isolation</transaction-isolation>"
-    fi
   fi
 
   if [ -n "$min_pool_size" ] || [ -n "$max_pool_size" ]; then
@@ -508,12 +508,11 @@ function generate_external_datasource_cli() {
           ds_tmp_xa_connection_properties["$prop_name"]="$prop_val"
         fi
       done
-
-      if [ -n "${tx_isolation}" ]; then
-        ds_tmp_key_values["transaction-isolation"]="${tx_isolation}"
-      fi
     fi
+  fi
 
+  if [ -n "${tx_isolation}" ]; then
+    ds_tmp_key_values["transaction-isolation"]="${tx_isolation}"
   fi
 
   if [ -n "$min_pool_size" ]; then


### PR DESCRIPTION
…on when defined by env variable

https://issues.redhat.com/browse/CLOUD-3544
https://issues.redhat.com/browse/JBEAP-18660

Based on the @luck3y's report I created this PR which brings the fix from the JBEAP-18660 to cekit module refactoring.

The expects the tests will be changed appropriately. Tests are part  of the `jboss-eap-modules` repository.
https://github.com/jboss-container-images/jboss-eap-modules/pull/188