### PR TITLE
[CLOUD-3549] Placeholder ##DEFAULT_DATASOURCE## is not replaced during the container startup process

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource-common.sh
@@ -172,11 +172,16 @@ function writeEEDefaultDatasource() {
 
   # Set the default datasource
   local defaultEEDatasourceConfMode
-  getConfigurationMode "<!-- ##DEFAULT_DATASOURCE## -->" "defaultEEDatasourceConfMode"
+  getConfigurationMode "##DEFAULT_DATASOURCE##" "defaultEEDatasourceConfMode"
   if [ "${defaultEEDatasourceConfMode}" = "xml" ]; then
     writeEEDefaultDatasourceXml
-  elif [ "${defaultEEDatasourceConfMode}" = "cli" ]; then
-    writeEEDefaultDatasourceCli
+  else
+    getConfigurationMode "<!-- ##DEFAULT_DATASOURCE## -->" "defaultEEDatasourceConfMode"
+    if [ "${defaultEEDatasourceConfMode}" = "xml" ]; then
+      writeEEDefaultDatasourceXml
+    elif [ "${defaultEEDatasourceConfMode}" = "cli" ]; then
+      writeEEDefaultDatasourceCli
+    fi
   fi
 }
 

--- a/jboss/container/wildfly/launch/datasources/test/datasource/common.bash
+++ b/jboss/container/wildfly/launch/datasources/test/datasource/common.bash
@@ -27,3 +27,9 @@ assert_datasources() {
   local xpath="//*[local-name()='datasources']"
   assert_xml $JBOSS_HOME/standalone/configuration/standalone-openshift.xml "$xpath" $BATS_TEST_DIRNAME/expectations/$expected
 }
+
+assert_defaut_bindings() {
+  local expected=$1
+  local xpath="//*[local-name()='default-bindings']"
+  assert_xml $JBOSS_HOME/standalone/configuration/standalone-openshift.xml "$xpath" $BATS_TEST_DIRNAME/expectations/$expected
+}

--- a/jboss/container/wildfly/launch/datasources/test/datasource/configure.bats
+++ b/jboss/container/wildfly/launch/datasources/test/datasource/configure.bats
@@ -356,3 +356,11 @@ load common
 
     assert_datasources "no-datasource-enabled-default.xml"
 }
+
+@test "inject_datasources: DATASOURCES - DEFAULT BINDINGS" {
+    ENABLE_GENERATE_DEFAULT_DATASOURCE="true"
+    run inject_datasources
+
+    [ "$status" -eq 0 ]
+    assert_defaut_bindings "default_bindings_placeholder.xml"
+}

--- a/jboss/container/wildfly/launch/datasources/test/datasource/expectations/default_bindings_placeholder.xml
+++ b/jboss/container/wildfly/launch/datasources/test/datasource/expectations/default_bindings_placeholder.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<default-bindings context-service="java:jboss/ee/concurrency/context/default"
+                    datasource="java:jboss/datasources/ExampleDS"
+                    jms-connection-factory="##DEFAULT_JMS##"
+                    managed-executor-service="java:jboss/ee/concurrency/executor/default"
+                    managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default"
+                    managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>


### PR DESCRIPTION
There are two different placeholders to set the default data source:

1. `##DEFAULT_DATASOURCE##`
2. `<!-- ##DEFAULT_DATASOURCE## -->`

The placeholder 1) was not replaced, which makes server fail at startup if the user this placeholder in his server config file.


Jira issue: https://issues.redhat.com/browse/CLOUD-3549
