### PR TITLE
[CLOUD-3553] Add default handler formatter to default logging.properties when configuration is final

### DIFF
--- a/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
+++ b/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
@@ -11,6 +11,8 @@ function configure_json_logging() {
     configureByMarkers
   elif [ "${configureMode}" = "cli" ]; then
     configureByCLI
+  else
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $LOGGING_FILE
   fi
 }
 


### PR DESCRIPTION
When `CONFIG_IS_FINAL` environment variable is `true`, then placeholder replacements and CLI configurations are not performed meaning the user supply the final server configuration file.

In order to avoid supply the initial logging.properties file, this path replace and initialises a default console formatter for the existing logging.properties in the image.

Jira issue: https://issues.redhat.com/browse/CLOUD-3553