### PR TITLE
[CLOUD-3554] Add default handler formatter to default logging.properties when configuration is final

### DIFF
--- a/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
+++ b/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
@@ -11,6 +11,8 @@ function configure_json_logging() {
     configureByMarkers
   elif [ "${configureMode}" = "cli" ]; then
     configureByCLI
+  else
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $LOGGING_FILE
   fi
 }
 


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/CLOUD-3554
Upstream Jira: https://issues.redhat.com/browse/CLOUD-3553
Upstream PR: https://github.com/wildfly/wildfly-cekit-modules/pull/173