### PR TITLE
Fix for CLOUD-3603, org.jboss.as.cli warning without message 

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
@@ -83,9 +83,8 @@ function processErrorsAndWarnings() {
     do
       log_warning "$line"
     done < "${CONFIG_WARNING_FILE}"
-
-    echo -n "" > "${CONFIG_WARNING_FILE}"
   fi
+  rm "${CONFIG_WARNING_FILE}"
   if [ -s "${CONFIG_ERROR_FILE}" ]; then
     echo "Error applying ${CLI_SCRIPT_FILE_FOR_EMBEDDED} CLI script. Embedded server started successfully. The Operations were executed but there were unexpected values. See list of errors in ${CONFIG_ERROR_FILE}"
     while IFS= read -r line


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3603

The processing of errors/warnings prior to start the server creates an empty warning file. this file should be deleted instead of emptying its content.