### PR TITLE
[0.18.x] Fix for CLOUD-3607, Move Image Builder non maven repo content out of tmp

### DIFF
--- a/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
+++ b/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
@@ -34,7 +34,10 @@ if [ -f "${ZIPPED_REPO}" ]; then
   unzip ${ZIPPED_REPO} -d /tmp
   repoDir=$(find /tmp -type d -iname "*-image-builder-maven-repository")
   mv $repoDir/maven-repository "$TMP_GALLEON_LOCAL_MAVEN_REPO"
-  
+  mkdir "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"
+  mv $repoDir/* "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"
+  rm -rf $repoDir
+
   if [ "x$deleteBuildArtifacts" == "xtrue"  ]; then
     echo "Build artifacts are not kept, will be removed from galleon local cache"
     cp -r $TMP_GALLEON_LOCAL_MAVEN_REPO $GALLEON_LOCAL_MAVEN_REPO

--- a/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
+++ b/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
@@ -35,7 +35,9 @@ if [ -f "${ZIPPED_REPO}" ]; then
   repoDir=$(find /tmp -type d -iname "*-image-builder-maven-repository")
   mv $repoDir/maven-repository "$TMP_GALLEON_LOCAL_MAVEN_REPO"
   mkdir "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"
-  mv $repoDir/* "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"
+  if [ "$(ls -A $repoDir)" ]; then
+    mv $repoDir/* "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"
+  fi
   rm -rf $repoDir
 
   if [ "x$deleteBuildArtifacts" == "xtrue"  ]; then


### PR DESCRIPTION
Issues: https://issues.redhat.com/browse/CLOUD-3607 and https://issues.redhat.com/browse/CLOUD-3769