### PR TITLE
Fix for WFLY-13577, Warning when deleting non existing CLI warning file

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/openshift-common.sh
@@ -84,7 +84,7 @@ function processErrorsAndWarnings() {
       log_warning "$line"
     done < "${CONFIG_WARNING_FILE}"
   fi
-  rm "${CONFIG_WARNING_FILE}"
+  rm -f "${CONFIG_WARNING_FILE}"
   if [ -s "${CONFIG_ERROR_FILE}" ]; then
     echo "Error applying ${CLI_SCRIPT_FILE_FOR_EMBEDDED} CLI script. Embedded server started successfully. The Operations were executed but there were unexpected values. See list of errors in ${CONFIG_ERROR_FILE}"
     while IFS= read -r line


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/WFLY-13577
