### PR TITLE
[Master] Fix for Issue #187, Add ability to execute a script once the maven repository has been unzipped.

### DIFF
--- a/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
+++ b/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
@@ -33,6 +33,11 @@ if [ -f "${ZIPPED_REPO}" ]; then
   echo "Found zipped repository, installing it."
   unzip ${ZIPPED_REPO} -d /tmp
   repoDir=$(find /tmp -type d -iname "*-image-builder-maven-repository")
+
+  # hook to allow for maven-repo processing before to initiate feature-pack build
+  if [ -f "$GALLEON_MAVEN_REPO_HOOK_SCRIPT" ]; then
+    sh $GALLEON_MAVEN_REPO_HOOK_SCRIPT "$repoDir"
+  fi
   mv $repoDir/maven-repository "$TMP_GALLEON_LOCAL_MAVEN_REPO"
   mkdir "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"
   mv $repoDir/* "$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR/maven-repo-misc"

--- a/jboss/container/wildfly/s2i/bash/module.yaml
+++ b/jboss/container/wildfly/s2i/bash/module.yaml
@@ -24,6 +24,8 @@ envs:
   value: "/opt/jboss/container/wildfly/s2i/galleon/settings.xml"
 - name: GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML
   value: /opt/jboss/container/wildfly/s2i/galleon/build-image-settings.xml
+- name: GALLEON_MAVEN_REPO_HOOK_SCRIPT
+  description: "Optional, path to a bash script to execute once the maven repository has been unzipped. Script is called with path to maven repo as argument."
 - name: GALLEON_S2I_FP_GROUP_ID
   description: "Mandatory. groupid of s2i galleon feature-pack"
 - name: GALLEON_S2I_FP_ARTIFACT_ID
@@ -31,7 +33,7 @@ envs:
 - name: GALLEON_VERSION
   value: "4.2.5.Final"
 - name: GALLEON_WILDFLY_VERSION
-  value: "4.2.6.Final"
+  value: "4.2.7.Final"
   description: "Set to true to explicitly add org.wildfly:wildfly-datasources-galleon-pack to provisoned galleon feature-packs."
 - name: GALLEON_S2I_PRODUCER_NAME
   description: Mandatory. Name of the built feature-pack producer.


### PR DESCRIPTION
Issue https://github.com/wildfly/wildfly-cekit-modules/issues/187

* Added script Hook.
* Upgraded wildfly galleon version to 4.2.7. Required for s2i Galleon feature-pack to express dependencies on Galleon patches.