### PR TITLE
JBEAP-19847 - bash syntax error occurs in keycloak.sh when CONFIG_IS_FINAL is enabled

### DIFF
--- a/jboss/container/wildfly/launch/keycloak/added/keycloak.sh
+++ b/jboss/container/wildfly/launch/keycloak/added/keycloak.sh
@@ -36,7 +36,7 @@ function prepareEnv() {
 function configure() {
   local configureSubSystemMode
   getConfigurationMode "##KEYCLOAK_SUBSYSTEM##" "configureSubSystemMode"
-  if [ $configureSubSystemMode == "xml" ]; then
+  if [ "${configureSubSystemMode}" == "xml" ]; then
     configure_keycloak
   else
     configure_cli_keycloak


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-19847
Upstream Issue: not required
Upstream PR: https://github.com/wildfly/wildfly-cekit-modules/pull/191