### PR TITLE
Fix for Issue #198, replicated-cache.memory.object has been renamed replicated-cache.memory.heap

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-infinispan.xml
+++ b/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-infinispan.xml
@@ -8,7 +8,7 @@
             <param name="default-cache" value="repl"/>
             <feature spec="subsystem.infinispan.cache-container.replicated-cache">
                 <param name="replicated-cache" value="repl"/>
-                <feature spec="subsystem.infinispan.cache-container.replicated-cache.memory.object">
+                <feature spec="subsystem.infinispan.cache-container.replicated-cache.memory.heap">
                     <param name="size" value="10000"/>
                 </feature>
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.component.locking">


### PR DESCRIPTION
Needed to upgrade to WF 21.