### PR TITLE
Revert "[CLOUD-3649] configure drivers from env variables prior datasource co…"

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/datasource.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/datasource.sh
@@ -27,10 +27,6 @@ function prepareEnv() {
 
 function configure() {
   initTempFiles
-  if [ -f /usr/local/s2i/install-common.sh ]; then
-    source /usr/local/s2i/install-common.sh
-    configure_drivers
-  fi
   inject_datasources
 }
 


### PR DESCRIPTION
Reverts wildfly/wildfly-cekit-modules#213

Reverting this as it appears to cause regressions in testing. Will comment on the JIRA