### PR TITLE
[CLOUD-3951] Bump maven module version to 3.6

### DIFF
--- a/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
+++ b/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
@@ -70,9 +70,9 @@ else
   rm /tmp/offliner.jar && rm /tmp/offliner.txt
 fi
 
-if [ -f $JBOSS_CONTAINER_MAVEN_35_MODULE/scl-enable-maven ]; then
+if [ -f $JBOSS_CONTAINER_MAVEN_36_MODULE/scl-enable-maven ]; then
   # required to have maven enabled.
-  source $JBOSS_CONTAINER_MAVEN_35_MODULE/scl-enable-maven
+  source $JBOSS_CONTAINER_MAVEN_36_MODULE/scl-enable-maven
 fi
 
 if [ -d "$JBOSS_HOME/modules" ]; then

--- a/jboss/container/wildfly/galleon/provision-server/configure.sh
+++ b/jboss/container/wildfly/galleon/provision-server/configure.sh
@@ -7,9 +7,9 @@ if [ ! -d "$GALLEON_DEFAULT_SERVER" ]; then
   exit 1
 fi
 
-if [ -f $JBOSS_CONTAINER_MAVEN_35_MODULE/scl-enable-maven ]; then
+if [ -f $JBOSS_CONTAINER_MAVEN_36_MODULE/scl-enable-maven ]; then
   # required to have maven enabled.
-  source $JBOSS_CONTAINER_MAVEN_35_MODULE/scl-enable-maven
+  source $JBOSS_CONTAINER_MAVEN_36_MODULE/scl-enable-maven
 fi
 
 # Provision the default server


### PR DESCRIPTION
Maven 3.5 got EOL'd. Bump it to v3.6

Signed-off-by: Daniel Kreling <dkreling@redhat.com>