### PR TITLE
Fix for CLOUD-3953, Arguments not conveyed to server if restarted after extensions applied

### DIFF
--- a/jboss/container/wildfly/launch-config/config/added/launch/launch.sh
+++ b/jboss/container/wildfly/launch-config/config/added/launch/launch.sh
@@ -134,7 +134,7 @@ function launchServer() {
   handleExtensions
   if [ $? -ne 0 ]; then
     log_info "Restarting the server"
-    ${cmd} &
+    ${cmd} ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} &
     pid=$!
   fi
   wait $pid 2>/dev/null


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3953