### PR TITLE
[CLOUD-3964] Remove default value for max metaspace

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
+++ b/jboss/container/wildfly/galleon/fp-content/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
@@ -1,7 +1,6 @@
 
 source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
 export GC_METASPACE_SIZE=${GC_METASPACE_SIZE:-96}
-export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
 
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 


### PR DESCRIPTION
Remove the Max value. This change is not enough.
In addition:
* cct_module needs to be fixed to not set a default max value: https://github.com/jboss-openshift/cct_module/pull/396
* Each image needs to provision a standalone.conf file that doesn't set the Max value: https://github.com/wildfly/wildfly-s2i/pull/152

