### PR TITLE
Updating postConfigure()

### DIFF
--- a/jboss/container/wildfly/launch/extensions/added/configure_extensions.sh
+++ b/jboss/container/wildfly/launch/extensions/added/configure_extensions.sh
@@ -4,16 +4,8 @@ function preConfigure() {
   preconfigure_extensions
 }
 
-# if a delayedpostconfigure.sh file exists call postconfigure.sh
-# The delayedpostconfigure.sh will be called after CLI execution.
-function postConfigure() {
-   if [ -f "${JBOSS_HOME}/extensions/delayedpostconfigure.sh" ]; then
-     postconfigure_extensions
-   fi
-}
-
 # if a delayedpostconfigure.sh file exists call it, otherwise fallback on postconfigure.sh
-function delayedPostConfigure() {
+function postConfigure() {
   if [ -f "${JBOSS_HOME}/extensions/delayedpostconfigure.sh" ]; then
     ${JBOSS_HOME}/extensions/delayedpostconfigure.sh
   else


### PR DESCRIPTION
Updating postConfigure to check if delayedpostconfigure.sh is present and execute it if present. Otherwise check if postconfigure.sh is present and execute it.

Hi,

The launch scripts for container images call postConfigure. Currently, if there is no delayedpostconfigure.sh present under $JBOSS_HOME/extensions then postconfigure.sh does not get invoked even it is there. I observed this behavior in the kieserver-rhel8 image:

https://catalog.redhat.com/software/containers/rhpam-7/rhpam-kieserver-rhel8/5db03b6cbed8bd164af2a202?container-tabs=dockerfile

The SSO image script does not have a delayed post configure but does directly call postconfigure. A colleague of mine was able to invoke postconfigure.sh by placing it under /opt/eap/extensions on a container running the SSO image. When I attempted to deploy the kieserver-rhel8 image, I needed to add an empty placeholder delayedpostconfigure.sh to get postconfigure.sh to execute. I'm not sure what the intent is, but please let me know if I can help with any modifications.

Thanks.