### PR TITLE
CLOUD-3979 The distributable-web subsystem needs to use <infinispan-routing cache-container="web" cache="routing"/>, instead of <local-routing/>.

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-clustering.xml
+++ b/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-clustering.xml
@@ -6,6 +6,8 @@
     <feature-group name="os-jgroups"/>
     <!-- infinispan -->
     <feature-group name="os-infinispan"/>
+    <!-- distributable-web (replacing the excluded local version) -->
+    <feature-group name="distributable-web"/>
     <!-- ha sockets -->
     <feature spec="socket-binding-group">
         <param name="socket-binding-group" value="standard-sockets"/>

--- a/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-clustering.xml
+++ b/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-clustering.xml
@@ -4,11 +4,11 @@
     <feature-group name="singleton"/>
     <!-- jgroups and ha sockets -->
     <feature-group name="os-jgroups"/>
-    <!-- inifinispan -->
+    <!-- infinispan -->
     <feature-group name="os-infinispan"/>
-        <!-- ha sockets -->
+    <!-- ha sockets -->
     <feature spec="socket-binding-group">
-        <param name="socket-binding-group" value="standard-sockets" />
+        <param name="socket-binding-group" value="standard-sockets"/>
         <feature-group name="ha-sockets">
             <exclude feature-id="socket-binding-group.socket-binding:name=standard-sockets,socket-binding=jgroups-udp-fd"/>
             <exclude feature-id="socket-binding-group.socket-binding:name=standard-sockets,socket-binding=jgroups-tcp-fd"/>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/CLOUD-3979
https://issues.redhat.com/browse/CLOUD-3980