### PR TITLE
Upgrade to galleon-plugins 5.2.0.Alpha2. Fixed elytron/configure.sh. GALLEON_FP_COMMON_PKG_NAME env is no more mandatory

### DIFF
--- a/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
+++ b/jboss/container/wildfly/galleon/build-feature-pack/configure.sh
@@ -21,11 +21,6 @@ if [ -z "$GALLEON_FP_PATH" ]; then
   exit 1
 fi
 
-if [ -z "$GALLEON_FP_COMMON_PKG_NAME" ]; then
-  echo "GALLEON_FP_COMMON_PKG_NAME must be set to the name of the galleon package containing common content"
-  exit 1
-fi
-
 deleteBuildArtifacts=${DELETE_BUILD_ARTIFACTS:-false}
 
 ZIPPED_REPO="/tmp/artifacts/maven-repo.zip"
@@ -98,10 +93,12 @@ mvn -f "$JBOSS_CONTAINER_WILDFLY_S2I_MODULE"/galleon/provisioning/jboss-s2i-univ
 rm -rf "$JBOSS_CONTAINER_WILDFLY_S2I_MODULE"/galleon/provisioning/jboss-s2i-universe
 rm -rf "$JBOSS_CONTAINER_WILDFLY_S2I_MODULE"/galleon/provisioning/jboss-s2i-producers
 
-# Copy JBOSS_HOME content (custom os content) to common package dir
-CONTENT_DIR=$GALLEON_FP_PATH/src/main/resources/packages/$GALLEON_FP_COMMON_PKG_NAME/content
-mkdir -p $CONTENT_DIR
-cp -r $JBOSS_HOME/* $CONTENT_DIR
+if [ ! -z "$GALLEON_FP_COMMON_PKG_NAME" ]; then
+  # Copy JBOSS_HOME content (custom os content) to common package dir
+  CONTENT_DIR=$GALLEON_FP_PATH/src/main/resources/packages/$GALLEON_FP_COMMON_PKG_NAME/content
+  mkdir -p $CONTENT_DIR
+  cp -r $JBOSS_HOME/* $CONTENT_DIR
+fi
 rm -rf $JBOSS_HOME/*
 
 # Build Galleon s2i feature-pack and install it in local maven repository

--- a/jboss/container/wildfly/galleon/build-feature-pack/module.yaml
+++ b/jboss/container/wildfly/galleon/build-feature-pack/module.yaml
@@ -13,7 +13,7 @@ envs:
 - name: GALLEON_FP_PATH
   description: "Mandatory. Absolute path to galleon feature-pack maven project."
 - name: GALLEON_FP_COMMON_PKG_NAME
-  description: "Mandatory. Name of galleon package that contains common content."
+  description: "Optional. Name of galleon package that contains common content."
 - name: GALLEON_BUILD_FP_MAVEN_ARGS_APPEND
   description: "Optional. Maven arguments to use when building galleon feature-pack."
 - name: OFFLINER_VERSION

--- a/jboss/container/wildfly/launch/elytron/configure.sh
+++ b/jboss/container/wildfly/launch/elytron/configure.sh
@@ -5,8 +5,6 @@ SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
 
-. $JBOSS_HOME/bin/launch/files.sh
-
 cp -p ${ADDED_DIR}/launch/elytron.sh ${JBOSS_HOME}/bin/launch/
 chmod ug+x ${JBOSS_HOME}/bin/launch/elytron.sh
 

--- a/jboss/container/wildfly/s2i/bash/module.yaml
+++ b/jboss/container/wildfly/s2i/bash/module.yaml
@@ -39,7 +39,7 @@ envs:
 - name: GALLEON_VERSION
   value: "4.2.8.Final"
 - name: GALLEON_WILDFLY_VERSION
-  value: "5.1.2.Final"
+  value: "5.2.0.Alpha2"
   description: "Set to true to explicitly add org.wildfly:wildfly-datasources-galleon-pack to provisoned galleon feature-packs."
 - name: GALLEON_S2I_PRODUCER_NAME
   description: Mandatory. Name of the built feature-pack producer.


### PR DESCRIPTION
These changes are needed in order to add more flexiility in the way cekit modules can be used to construct an image.
* Upgrade to 5.2.0.Alpha2 contains a fix that has been revealed when building a FP that depends on more than one FP.
* The elytron/configure.sh script was sourcing a file for no reason.
* GALLEON_FP_COMMON_PKG_NAME env that used to be mandatory in order to copy content from JBOSS_HOME to the s2i FP is no more mandatory.
These changes are needed by: https://github.com/wildfly/wildfly-s2i/pull/173 