### PR TITLE
[V2] Support execution of a CLI script at runtime

### DIFF
--- a/jboss/container/wildfly/run/api/module.yaml
+++ b/jboss/container/wildfly/run/api/module.yaml
@@ -5,7 +5,11 @@ description: Env variable to configure the server for cloud execution. JVM is au
 
 envs:
 - name: JAVA_OPTS_APPEND
-  description: To append options to JAVA_OPTS env variabke.
+  description: To append options to JAVA_OPTS env variable.
+- name: CLI_LAUNCH_SCRIPT
+  description: A path to a CLI script to execute at server launch time. The path can be absolute or relative to $JBOSS_HOME directory. If an error occurs during script execution, the server startup aborts and CLI errors are displayed in the console. Management operations that imply a restart of the server are not supported in such CLI script.
+- name: CLI_EXECUTION_OUTPUT
+  description: By default executed CLI script output is redirected to '/tmp/server-cli-execution-output-file.txt' file. Set this env variable to `CONSOLE` for output to be displayed in the console. Set this env variable to a file path for output to be redirected in the provided file".
 - name: PORT_OFFSET
   description: Use this env variable to set the server port offset. This is advised practice instead of directly setting jboss.socket.binding.port-offset in the SERVER_ARGS. It allows the server shutdown logic to connect to the running server to do a clean CLI shutdown. 
 - name: CLI_GRACEFUL_SHUTDOWN

--- a/jboss/container/wildfly/run/bash/artifacts/opt/jboss/container/wildfly/run/run
+++ b/jboss/container/wildfly/run/bash/artifacts/opt/jboss/container/wildfly/run/run
@@ -137,6 +137,32 @@ else
 
     SERVER_ARGS="${JAVA_PROXY_OPTIONS} -Djboss.node.name=${JBOSS_NODE_NAME} ${PORT_OFFSET_PROPERTY} -b ${PUBLIC_IP_ADDRESS} -bmanagement ${MANAGEMENT_IP_ADDRESS} -Dwildfly.statistics-enabled=${ENABLE_STATISTICS} ${SERVER_ARGS}"
 
+    if [ -n "${CLI_LAUNCH_SCRIPT}" ]; then
+      if [ ! -f "${CLI_LAUNCH_SCRIPT}" ]; then
+        scriptFile="${JBOSS_HOME}/${CLI_LAUNCH_SCRIPT}"
+        if [ ! -f "${scriptFile}" ]; then
+          log_error "${CLI_LAUNCH_SCRIPT} doesn't exist or is not a relative path inside ${JBOSS_HOME}"
+          exit 1
+        fi
+      else
+        scriptFile="${CLI_LAUNCH_SCRIPT}"
+      fi
+      log_info "Executing CLI script ${scriptFile} during server startup"
+      markerDir=/tmp/server-cli-boot-hook-dir
+      rm -rf "${markerDir}"
+      mkdir "${markerDir}"
+      bootHookOptions="--start-mode=admin-only -Dorg.wildfly.internal.cli.boot.hook.script=${scriptFile} -Dorg.wildfly.internal.cli.boot.hook.marker.dir=${markerDir}"
+      outputLocation="${CLI_EXECUTION_OUTPUT:-/tmp/server-cli-execution-output-file.txt}"
+      if [ "${outputLocation}" == "CONSOLE" ]; then
+        log_info "CLI execution output displayed in the console"
+      else
+        rm -f "${outputLocation}"
+        bootHookOptions="${bootHookOptions} -Dorg.wildfly.internal.cli.boot.hook.script.output.file=${outputLocation}"
+        log_info "CLI execution output redirected to ${outputLocation}"
+      fi
+
+      SERVER_ARGS="${SERVER_ARGS}  ${bootHookOptions}"
+    fi
     log_info "Starting server with arguments: ${SERVER_ARGS}"
 
     export JAVA_OPTS


### PR DESCRIPTION
* Introduce the ability to run a CLI script at startup. Run script and API updated.
* Ability to set CLI output location (by default in a file but can be displayed in the console).
* New behave tests will be added in a wildfly-s2i PR.