### PR TITLE
Set default expiration value to 0 for infinispan replicated caches

### DIFF
--- a/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-infinispan-web-repl-cache.xml
+++ b/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-infinispan-web-repl-cache.xml
@@ -12,6 +12,9 @@
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.component.transaction">
                     <param name="mode" value="BATCH"/>
                 </feature>
+                <feature spec="subsystem.infinispan.cache-container.replicated-cache.component.expiration">
+                    <param name="interval" value="0"/>
+                </feature>
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.store.file">
                     <unset param="relative-to"/>
                 </feature>

--- a/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-infinispan.xml
+++ b/jboss/container/wildfly/galleon/fp-content/config/added/src/main/resources/feature_groups/os-infinispan.xml
@@ -17,6 +17,9 @@
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.component.transaction">
                     <param name="mode" value="BATCH"/>
                 </feature>
+                <feature spec="subsystem.infinispan.cache-container.replicated-cache.component.expiration">
+                    <param name="interval" value="0"/>
+                </feature>
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.store.file">
                     <unset param="relative-to"/>
                 </feature>


### PR DESCRIPTION
* Fix replicated caches added to server configuration. Caused by https://issues.redhat.com/browse/WFLY-14935
