### PR TITLE
[CLOUD-4021] dot is not permitted in tx datasource table name

### DIFF
--- a/jboss/container/wildfly/launch/datasources/added/launch/tx-datasource.sh
+++ b/jboss/container/wildfly/launch/datasources/added/launch/tx-datasource.sh
@@ -61,6 +61,7 @@ function inject_jdbc_store() {
   init_node_name
 
   local prefix="os${JBOSS_NODE_NAME//-/}"
+  prefix="${prefix//.}"
 
   local dsConfMode
   getConfigurationMode "<!-- ##JDBC_STORE## -->" "dsConfMode"


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4021
https://issues.redhat.com/browse/EAPSUP-592

master PR: https://github.com/wildfly/wildfly-cekit-modules/pull/257
0.18.x: https://github.com/wildfly/wildfly-cekit-modules/pull/259