### PR TITLE
Introduce legacy s2i module to enable current s2i workflow

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
@@ -8,6 +8,5 @@ source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/s2i-core-hooks"
 # inject our overridden maven_s2i_*() functions
 source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/maven-s2i-overrides"
 
-export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -Dcom.redhat.xpaas.repo.jbossorg"
 # invoke the build
 maven_s2i_build

--- a/jboss/container/wildfly/s2i/bash/artifacts/usr/local/s2i/usage
+++ b/jboss/container/wildfly/s2i/bash/artifacts/usr/local/s2i/usage
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-cat <<EOF
-This is an S2I WildFly ubi8 based image responsible for installing and running a WildFly server and application on JDK 11.
-
-Documentation on how to use this image can be found there: https://github.com/wildfly/wildfly-s2i
-
-EOF

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
+
+if [ -n "${GALLEON_PROVISION_LAYERS}" ]; then
+   if [ -z "${GALLEON_PROVISION_FEATURE_PACKS}" ]; then
+     log_error "GALLEON_PROVISION_FEATURE_PACKS env variable must be set when GALLEON_PROVISION_LAYERS is set"
+     exit 1
+   fi
+fi
+if [ -n "${GALLEON_PROVISION_FEATURE_PACKS}" ]; then
+   if [ -z "${GALLEON_PROVISION_LAYERS}" ]; then
+     log_error "GALLEON_PROVISION_LAYERS env variable must be set when GALLEON_PROVISION_FEATURE_PACKS is set"
+     exit 1
+   fi
+fi
+if [ -n "${GALLEON_PROVISION_FEATURE_PACKS}" ]; then
+  # Legacy s2i workflow integration
+  #For backward compatibility
+  export CONFIG_ADJUSTMENT_MODE=cli
+  source "${JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE}/s2i-core-hooks"
+  source "${JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE}/s2i_galleon"
+  
+  galleon_provision_server
+else
+  # include our overrides/extensions
+  source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/s2i-core-hooks"
+
+  # inject our overridden maven_s2i_*() functions
+  source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/maven-s2i-overrides"
+fi
+# invoke the build
+maven_s2i_build

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/config.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
+    <layers>
+        <!-- ##GALLEON_LAYERS## -->
+    </layers>
+</config>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/pom.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.galleon.s2i</groupId>
+        <artifactId>galleon-s2i-parent</artifactId>
+        <version>1.0.0.Final</version>
+    </parent>
+    <artifactId>layers-provisioning</artifactId>
+    <packaging>pom</packaging>
+    <name>Provision a set of Galleon layers from s2i feature-pack</name>
+  
+    <description>Provision a set of Galleon layers from s2i feature-pack</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.galleon</groupId>
+                <artifactId>galleon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>wildfly-provisioning-layers ${env.GALLEON_PROVISION_LAYERS}</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <install-dir>${project.build.directory}/server</install-dir>
+                            <record-state>true</record-state>
+                            <offline>false</offline>
+                            <plugin-options>
+                                <!-- required when running on JDK 11 -->
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </plugin-options>
+                            <feature-packs>
+                                <!-- ##GALLEON_FEATURE_PACKS## -->
+                            </feature-packs>
+                            <customConfig>config.xml</customConfig>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/pom.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jboss.galleon.s2i</groupId>
+    <artifactId>galleon-s2i-parent</artifactId>
+    <version>1.0.0.Final</version>
+    <packaging>pom</packaging>
+    <name>Provision servers with Galleon during S2I</name>
+  
+    <description>Provision servers with Galleon during S2I</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <properties>
+        <version.org.jboss.galleon>${env.GALLEON_VERSION}</version.org.jboss.galleon>
+    </properties>
+    <modules>
+        <module>generic_layers</module>
+    </modules>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jboss.galleon</groupId>
+                    <artifactId>galleon-maven-plugin</artifactId>
+                    <version>${version.org.jboss.galleon}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i-core-hooks
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i-core-hooks
@@ -1,0 +1,58 @@
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+# override core variables
+function s2i_core_env_init_hook() {
+  wildfly_s2i_env_init
+}
+
+# add support for copying modules
+function s2i_core_copy_artifacts_hook() {
+  wildfly_s2i_copy_modules $*
+  wildfly_s2i_copy_cfg $*
+}
+
+# Overrides are done in the script vs image configuration so $JBOSS_HOME can be
+#   used, simplifying configuration for layered products
+# Override target configuration directory
+# Override target data directory
+# Initialize variables for source/target directories for modules
+function wildfly_s2i_env_init() {
+  S2I_TARGET_CONFIGURATION_DIR="${S2I_TARGET_CONFIGURATION_DIR:-${JBOSS_HOME}/standalone/configuration}"
+  S2I_TARGET_DATA_DIR="${S2I_TARGET_DATA_DIR:-${DATA_DIR:-${JBOSS_HOME}/standalone/data}}"
+
+  WILDFLY_S2I_SOURCE_MODULES_DIR="${WILDFLY_S2I_SOURCE_MODULES_DIR:-modules}"
+  WILDFLY_S2I_TARGET_MODULES_DIR="${WILDFLY_S2I_TARGET_MODULES_DIR:-${JBOSS_HOME}/modules}"
+}
+
+# copy modules
+function wildfly_s2i_copy_modules() {
+  if [ -d "${1}/${WILDFLY_S2I_SOURCE_MODULES_DIR}" ]; then
+    if [ -z "${WILDFLY_S2I_TARGET_MODULES_DIR}" ]; then
+      log_warning "Unable to copy modules files.  No target directory specified for WILDFLY_S2I_TARGET_MODULES_DIR"
+    else
+      if [ ! -d "${WILDFLY_S2I_TARGET_MODULES_DIR}" ]; then
+        log_info "WILDFLY_S2I_TARGET_MODULES_DIR does not exist, creating ${WILDFLY_S2I_TARGET_MODULES_DIR}"
+        mkdir -pm 775 "${WILDFLY_S2I_TARGET_MODULES_DIR}"
+      fi
+      log_info "Copying modules from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${WILDFLY_S2I_SOURCE_MODULES_DIR}) to ${WILDFLY_S2I_TARGET_MODULES_DIR}..."
+      rsync -rl --out-format='%n' "${1}/${WILDFLY_S2I_SOURCE_MODULES_DIR}"/ "${WILDFLY_S2I_TARGET_MODULES_DIR}"
+    fi
+  fi 
+}
+
+# copy cfg
+function wildfly_s2i_copy_cfg() {
+  if [ -d "${1}/cfg" ]; then
+    if [ -z "${S2I_TARGET_CONFIGURATION_DIR}" ]; then
+      log_warning "Unable to copy configuration files.  No target directory specified for S2I_TARGET_CONFIGURATION_DIR"
+    else
+      if [ ! -d "${S2I_TARGET_CONFIGURATION_DIR}" ]; then
+        log_info "S2I_TARGET_CONFIGURATION_DIR does not exist, creating ${S2I_TARGET_CONFIGURATION_DIR}"
+        mkdir -pm 775 "${S2I_TARGET_CONFIGURATION_DIR}"
+      fi
+      log_info "Copying configuration from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/cfg) to ${S2I_TARGET_CONFIGURATION_DIR}..."
+      rsync -rl --out-format='%n' "${1}/cfg"/ "${S2I_TARGET_CONFIGURATION_DIR}"
+    fi
+  fi 
+}

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
@@ -1,0 +1,180 @@
+GALLEON_GENERIC_LAYERS_DEFINITION="$JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE"/provisioning/generic_layers
+
+function galleon_patch_generic_config() {
+   if [ -n "$GALLEON_PROVISION_LAYERS" ]; then
+     for layer in $(echo $GALLEON_PROVISION_LAYERS | sed "s/,/ /g"); do
+       if [[ "$layer" =~ ^-.* ]]; then
+         layer="${layer:1}"
+         layers="$layers<exclude name=\"$layer\"/>"
+       else
+         layers="$layers<include name=\"$layer\"/>"
+       fi
+     done
+     if [ -n "$layers" ]; then
+       sed -i "s|<!-- ##GALLEON_LAYERS## -->|${layers}|" $GALLEON_GENERIC_LAYERS_DEFINITION/config.xml
+     fi
+   fi
+   if [ -n "$GALLEON_PROVISION_FEATURE_PACKS" ]; then
+     echo Provisioning Galleon feature-packs: $GALLEON_PROVISION_FEATURE_PACKS
+     for fp in $(echo "${GALLEON_PROVISION_FEATURE_PACKS}" | sed "s/,/ /g"); do
+       featurepacks="$featurepacks<feature-pack><inherit-packages>false</inherit-packages><inherit-configs>false</inherit-configs>"
+       featurepacks="$featurepacks<location>$fp</location></feature-pack>"
+     done
+     if [ -n "$featurepacks" ]; then
+       sed -i "s|<!-- ##GALLEON_FEATURE_PACKS## -->|${featurepacks}|" $GALLEON_GENERIC_LAYERS_DEFINITION/pom.xml
+     fi
+   fi
+}
+
+
+function galleon_init_mvn_env() {
+    # store original MAVEN_ARGS, MAVEN_ARGS_APPEND and MAVEN_LOCAL_REPO
+    if [ -n "$MAVEN_ARGS" ]; then
+      ORIGINAL_MAVEN_ARGS=${MAVEN_ARGS}
+    fi
+    if [ -n "$MAVEN_ARGS_APPEND" ]; then
+      ORIGINAL_MAVEN_ARGS_APPEND=${MAVEN_ARGS_APPEND}
+      unset MAVEN_ARGS_APPEND
+    fi
+    if [ -n "$MAVEN_LOCAL_REPO" ]; then
+      ORIGINAL_MAVEN_LOCAL_REPO=$MAVEN_LOCAL_REPO
+    fi
+    if [ -n "$MAVEN_SETTINGS_XML" ]; then
+      ORIGINAL_MAVEN_SETTINGS_XML=$MAVEN_SETTINGS_XML
+    fi
+
+    # Need to compute the project src root dir.
+    dest_dir="${S2I_DESTINATION_DIR:-/tmp}"
+    GALLEON_PROJECT_SRC_DIR="${dest_dir}/src"
+    
+    # Identify custom galleon content directory
+    if [ -n "${GALLEON_DIR}" ]; then
+      GALLEON_LOCAL_PROVISIONING="${GALLEON_PROJECT_SRC_DIR}/${GALLEON_DIR}"
+      if [ ! -d "${GALLEON_LOCAL_PROVISIONING}" ]; then
+        log_error "$GALLEON_DIR directory referenced by GALLEON_DIR env variable doesn't exist in the project. Exiting."
+        exit 1
+      fi
+    else
+      GALLEON_LOCAL_PROVISIONING="${GALLEON_PROJECT_SRC_DIR}/galleon"
+    fi
+    # Set galleon settings prior to init maven.
+    # Doing so default settings.xml are untouched.
+    if [ -f "${GALLEON_LOCAL_PROVISIONING}/settings.xml" ]; then
+      MAVEN_SETTINGS_XML="${GALLEON_LOCAL_PROVISIONING}/settings.xml"
+      echo "Using ${MAVEN_SETTINGS_XML} when provisioning server."
+    else
+      cp $HOME/.m2/settings.xml /tmp/galleon-settings.xml
+      MAVEN_SETTINGS_XML=/tmp/galleon-settings.xml
+    fi
+    if test -r "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven; then
+      source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven
+    fi
+    source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/maven.sh
+    # Initialize Maven
+    maven_init
+    unset MAVEN_ARGS
+    maven_init_var_MAVEN_ARGS    
+    # GALLEON_MAVEN_ARGS is mainly to enable nexus profile 
+    MAVEN_ARGS="$MAVEN_ARGS $GALLEON_MAVEN_ARGS"
+}
+
+function galleon_reset_mvn_env() {
+    # restore MAVEN_LOCAL_REPO
+    unset MAVEN_LOCAL_REPO
+    if [ -n "$ORIGINAL_MAVEN_LOCAL_REPO" ]; then
+      MAVEN_LOCAL_REPO=$ORIGINAL_MAVEN_LOCAL_REPO
+    fi
+
+    # restore MAVEN_SETTINGS_XML
+    unset MAVEN_SETTINGS_XML
+    if [ -n "$ORIGINAL_MAVEN_SETTINGS_XML" ]; then
+      MAVEN_SETTINGS_XML=$ORIGINAL_MAVEN_SETTINGS_XML
+    fi
+
+    # reset args to be clean when consumed by s2i
+    # MAVEN_ARGS could contain Galleon local repository
+    unset MAVEN_ARGS
+    if [ -n "$ORIGINAL_MAVEN_ARGS" ]; then
+      MAVEN_ARGS=${ORIGINAL_MAVEN_ARGS}
+    fi
+
+    if [ -n "$ORIGINAL_MAVEN_ARGS_APPEND" ]; then
+      MAVEN_ARGS_APPEND=${ORIGINAL_MAVEN_ARGS_APPEND}
+    fi
+}
+
+
+function install_custom_fps() {
+  if [ -n "$GALLEON_CUSTOM_FEATURE_PACKS_MAVEN_REPO" ]; then
+    if [ -d "$GALLEON_CUSTOM_FEATURE_PACKS_MAVEN_REPO" ]; then
+      copy_custom_fps "$GALLEON_CUSTOM_FEATURE_PACKS_MAVEN_REPO"
+    else
+      log_error "$GALLEON_CUSTOM_FEATURE_PACKS_MAVEN_REPO directory referenced by GALLEON_CUSTOM_FEATURE_PACKS_MAVEN_REPO env variable doesn't exist. Exiting."
+      exit 1
+    fi
+  else
+    if [ -d "$GALLEON_LOCAL_PROVISIONING/repository" ]; then
+      copy_custom_fps "$GALLEON_LOCAL_PROVISIONING/repository"
+    fi
+  fi
+}
+
+function copy_custom_fps() {
+  pushd "$1" &> /dev/null
+  echo "Copying custom fp in $1 to $MAVEN_LOCAL_REPO"
+  mkdir -p "$MAVEN_LOCAL_REPO"
+  cp -r * "$MAVEN_LOCAL_REPO"
+  popd &> /dev/null
+}
+
+function galleon_provision_server() {
+    galleon_init_mvn_env
+    install_custom_fps
+    GALLEON_ROOT_DIR=${GALLEON_DEFINITIONS}
+
+    if [ -n "$GALLEON_PROVISION_LAYERS" ]; then
+      galleon_patch_generic_config
+      GALLEON_DESCRIPTION_LOCATION="$GALLEON_GENERIC_LAYERS_DEFINITION"
+      if [ -f $GALLEON_LOCAL_PROVISIONING/provisioning.xml ]; then
+        echo "Galleon provisioning of layers overrides Galleon provisioning.xml located in $GALLEON_LOCAL_PROVISIONING"
+      fi
+    fi
+      
+      if [ -f "$GALLEON_DESCRIPTION_LOCATION/pom.xml" ]; then
+          echo "Provisioning WildFly server..."
+          maven_build "$GALLEON_DESCRIPTION_LOCATION" package
+
+          ERR=$?
+          if [ $ERR -ne 0 ]; then
+            log_error "Aborting due to error code $ERR from mvn install"
+            exit $ERR
+          fi
+          targetDir=$GALLEON_DESCRIPTION_LOCATION/target/server
+          if [ -d $targetDir ]; then
+            galleon_replace_server $targetDir
+            rm -rf $targetDir
+          else
+            echo "Error, no server provisioned in $targetDir"
+            exit 1
+          fi
+      else
+          log_error "Not a valid galleon description $GALLEON_DESCRIPTION_LOCATION exiting"
+          exit 1
+      fi
+    galleon_reset_mvn_env
+}
+
+function galleon_replace_server() {
+  echo "Installing server"
+  srcDir=$1
+  mkdir -p $JBOSS_HOME
+  cp -prf $srcDir/* $JBOSS_HOME
+  cp -prf $srcDir/.galleon $JBOSS_HOME/.galleon
+  cp -prf $JBOSS_HOME/standalone/deployments/* /deployments
+  rm -rf $JBOSS_HOME/standalone/deployments
+  ln -s /deployments $JBOSS_HOME/standalone/deployments
+  # CLOUD-3855 - in certain cases when deploying onto the same image in openshift, we don't have permissions
+  # to chown from our running, random UID to the jboss user. So just chown to the current user (which will be root in a docker build
+  # and a random uid elsewhere)
+  chown -R ${USER}:root $JBOSS_HOME && chmod -R ug+rwX $JBOSS_HOME
+}

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+LOCAL_SOURCE_DIR=/tmp/src
+
+# Resulting WAR files will be deployed to /opt/eap/standalone/deployments
+DEPLOY_DIR=$JBOSS_HOME/standalone/deployments
+
+source ${JBOSS_HOME}/bin/launch/openshift-common.sh
+
+
+function find_env() {
+  var=${!1}
+  echo "${var:-$2}"
+}
+
+function install_deployments(){
+  if [ $# != 1 ]; then
+    echo "Usage: Directory parameter required"
+    return
+  fi
+  install_dirs=$1
+
+  for install_dir in $(echo $install_dirs | sed "s/,/ /g"); do
+    cp -rf ${install_dir}/* $DEPLOY_DIR
+  done
+}
+
+function install_modules(){
+  if [ $# != 1 ]; then
+    echo "Usage: Directory parameter required"
+    return
+  fi
+  install_dirs=$1
+
+  for install_dir in $(echo $install_dirs | sed "s/,/ /g"); do
+    cp -rf ${install_dir}/* $JBOSS_HOME/modules
+  done
+}
+
+function configure_drivers(){
+  (
+    if [ $# == 1 ] && [ -f "$1" ]; then
+      source $1
+    fi
+
+    drivers=
+    if [ -n "$DRIVERS" ]; then
+      local configMode
+      getConfigurationMode "<!-- ##DRIVERS## -->" "configMode"
+
+      for driver_prefix in $(echo $DRIVERS | sed "s/,/ /g"); do
+        driver_module=$(find_env "${driver_prefix}_DRIVER_MODULE")
+        if [ -z "$driver_module" ]; then
+          echo "Warning - ${driver_prefix}_DRIVER_MODULE is missing from driver configuration. Driver will not be configured"
+          continue
+        fi
+
+        driver_name=$(find_env "${driver_prefix}_DRIVER_NAME")
+        if [ -z "$driver_name" ]; then
+          echo "Warning - ${driver_prefix}_DRIVER_NAME is missing from driver configuration. Driver will not be configured"
+          continue
+        fi
+
+        driver_class=$(find_env "${driver_prefix}_DRIVER_CLASS")
+        datasource_class=$(find_env "${driver_prefix}_XA_DATASOURCE_CLASS")
+        if [ -z "$driver_class" ] && [ -z "$datasource_class" ]; then
+          echo "Warning - ${driver_prefix}_DRIVER_NAME and ${driver_prefix}_XA_DATASOURCE_CLASS is missing from driver configuration. At least one is required. Driver will not be configured"
+          continue
+        fi
+
+        if [ "${configMode}" = "xml" ]; then
+          drivers="${drivers} <driver name=\"$driver_name\" module=\"$driver_module\">"
+          if [ -n "$datasource_class" ]; then
+            drivers="${drivers}<xa-datasource-class>${datasource_class}</xa-datasource-class>"
+          fi
+
+          if [ -n "$driver_class" ]; then
+            drivers="${drivers}<driver-class>${driver_class}</driver-class>"
+          fi
+          drivers="${drivers}</driver>"
+        elif [ "${configMode}" = "cli" ]; then
+          drivers="${drivers}
+            if (outcome == success) of /subsystem=datasources/jdbc-driver=${driver_name}:read-resource
+              echo \"Cannot add the driver with name ${driver_name}. There is a driver with the same name already configured.\" >> \${error_file}
+              quit
+            else
+              /subsystem=datasources/jdbc-driver=${driver_name}:add(driver-name=\"${driver_name}\", driver-module-name=\"${driver_module}\""
+            if [ -n "$datasource_class" ]; then
+              drivers="${drivers}, driver-xa-datasource-class-name=\"${datasource_class}\""
+            fi
+            if [ -n "$driver_class" ]; then
+              drivers="${drivers}, driver-class-name=\"${driver_class}\""
+            fi
+            drivers="${drivers})
+            end-if
+          "
+        fi
+      done
+
+      if [ -n "$drivers" ] ; then
+        if [ "${configMode}" = "xml" ]; then
+          sed -i "s|<!-- ##DRIVERS## -->|${drivers}<!-- ##DRIVERS## -->|" $CONFIG_FILE
+        elif [ "${configMode}" = "cli" ]; then
+          if [ "${CONFIG_ADJUSTMENT_MODE,,}" = "cli" ]; then
+            # CLI execution to add current driver(s)
+            echo "${drivers}" > ${S2I_CLI_DRIVERS_FILE}
+            exec_cli_scripts "${S2I_CLI_DRIVERS_FILE}"
+          else
+            # append to CLI script for delayed CLI execution at server launch
+            echo "${drivers}" >> ${S2I_CLI_DRIVERS_FILE}
+          fi
+        fi
+      fi
+    fi
+  )
+}
+
+if [ -s /usr/local/s2i/install-common-overrides.sh ]; then
+  source /usr/local/s2i/install-common-overrides.sh
+fi

--- a/jboss/container/wildfly/s2i/legacy/configure.sh
+++ b/jboss/container/wildfly/s2i/legacy/configure.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/wildfly/s2i/assemble.sh
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# Kept for backward compatibility
+ln -s /opt/jboss/container/wildfly/s2i/install-common/install-common.sh /usr/local/s2i/install-common.sh
+chown -h jboss:root /usr/local/s2i/install-common.sh

--- a/jboss/container/wildfly/s2i/legacy/module.yaml
+++ b/jboss/container/wildfly/s2i/legacy/module.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+name: jboss.container.wildfly.s2i.legacy
+version: '1.0'
+description: Ability to provision a server thanks to env variables, legacy workflow
+
+envs:
+- name: JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE
+  value: "/opt/jboss/container/wildfly/s2i/galleon"
+- name: GALLEON_VERSION
+  value: "4.2.8.Final"
+- name: S2I_SOURCE_DEPLOYMENTS_FILTER
+  value: "*.war *.ear *.rar *.jar"
+
+execute:
+- script: configure.sh
+
+modules:
+  install:
+  - name: jboss.container.wildfly.s2i.bash


### PR DESCRIPTION
* A cekit module that captures legacy s2i workflow (galleon provisioning, copy of content into server, calling extensions).
* Clean-up s2i cekit module from WildFly specific setup, allow to be shared with other technologies.