### PR TITLE
CLOUD-4046 Deploy on dual-stack ocp4.8 fails

### DIFF
--- a/jboss/container/wildfly/launch/jgroups/added/launch/ha.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/ha.sh
@@ -287,7 +287,7 @@ generate_dns_ping_config() {
 
 configure_ha_args() {
   # Set HA args
-  IP_ADDR=`hostname -i`
+  IP_ADDR=$(get_host_ipv4)
   JBOSS_HA_ARGS="-b ${JBOSS_HA_IP:-${IP_ADDR}} -bprivate ${JBOSS_HA_IP:-${IP_ADDR}}"
 
   init_node_name

--- a/jboss/container/wildfly/launch/keycloak/1.0/added/keycloak.sh
+++ b/jboss/container/wildfly/launch/keycloak/1.0/added/keycloak.sh
@@ -791,7 +791,7 @@ function configure_client() {
       client_config="${client_config},\"attributes\":{\"saml.signing.certificate\":\"${pem}\"${server_signature}}"
     fi
   else
-    service_addr=$(hostname -i)
+    service_addr=$(get_host_ipv4)
     client_config="{\"redirectUris\":[${redirects}]"
 
     if [ -n "$HOSTNAME_HTTP" ]; then

--- a/jboss/container/wildfly/launch/messaging/added/launch/messaging.sh
+++ b/jboss/container/wildfly/launch/messaging/added/launch/messaging.sh
@@ -77,7 +77,7 @@ function configure() {
 }
 
 function configure_artemis_address() {
-    IP_ADDR=${JBOSS_MESSAGING_HOST:-`hostname -i`}
+    IP_ADDR=${JBOSS_MESSAGING_HOST:-$(get_host_ipv4)}
     JBOSS_MESSAGING_ARGS="${JBOSS_MESSAGING_ARGS} -Djboss.messaging.host=${IP_ADDR}"
 }
 # /subsystem=messaging-activemq/server=default/jms-queue=queue_name:add(entries=[])


### PR DESCRIPTION
On a dual-stack OpenShift cluster the command 'hostname -i' gives two IPs back. We only need one IP, either IPv4 or IPv6, to build JBOSS_HA_ARGS.


Please make sure your PR meets the following requirements:

[ x] Pull Request title is properly formatted: [CLOUD-4046] Subject
[ x] Pull Request contains link to the JIRA issue
https://issues.redhat.com/browse/CLOUD-4046
[ x] Pull Request contains a description of the issue
On a dual-stack openshift cluster the command 'hostname -i' returns both IPs (IPv4 and IPv6). To fill IP_ADDR. That var IP_ADDR is directly used to build the var JBOSS_HA_ARG. So we get a double IP while it should be one IP.
[x ] Pull Request does not include fixes for issues other than the main ticket
[ x] Attached commits represent units of work and are properly formatted
[ x] You have read and agreed to the Developer Certificate of Origin (DCO) (see CONTRIBUTING.md)