### PR TITLE
Fix for Issue #277, Provisioning based on env variables should use WildFly maven plugin

### DIFF
--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/default_config/pom.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/default_config/pom.xml
@@ -40,36 +40,23 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>${s2i.provisioning.maven.plugin.groupId}</groupId>
+                <artifactId>${s2i.provisioning.maven.plugin.artifactId}</artifactId>
                 <executions>
                     <execution>
-                        <id>wildfly-provisioning-default-config</id>
+                        <id>provisioning-default-config</id>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>package</goal>
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/server</install-dir>
-                            <record-state>true</record-state>
-                            <offline>false</offline>
-                            <plugin-options>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <galleon-options>
                                 <!-- required when running on JDK 11 -->
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
-                                <feature-pack>
-                                    <location><!-- ##GALLEON_FEATURE_PACK## --></location>
-                                    <inherit-packages>true</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                        </config>
-                                    </included-configs>
-                                </feature-pack>
+                                <!-- ##GALLEON_FEATURE_PACKS## -->
                             </feature-packs>
                         </configuration>
                     </execution>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/config.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" ?>
-<config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
-    <layers>
-        <!-- ##GALLEON_LAYERS## -->
-    </layers>
-</config>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/pom.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_layers/pom.xml
@@ -40,28 +40,30 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>${s2i.provisioning.maven.plugin.groupId}</groupId>
+                <artifactId>${s2i.provisioning.maven.plugin.artifactId}</artifactId>
                 <executions>
                     <execution>
-                        <id>wildfly-provisioning-layers ${env.GALLEON_PROVISION_LAYERS}</id>
+                        <id>provisioning-layers ${env.GALLEON_PROVISION_LAYERS}</id>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>package</goal>
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/server</install-dir>
-                            <record-state>true</record-state>
-                            <offline>false</offline>
-                            <plugin-options>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <galleon-options>
                                 <!-- required when running on JDK 11 -->
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
                                 <!-- ##GALLEON_FEATURE_PACKS## -->
                             </feature-packs>
-                            <customConfig>config.xml</customConfig>
+                            <layers>
+                                <!-- ##GALLEON_INCLUDED_LAYERS## -->
+                            </layers>
+                            <excluded-layers>
+                                <!-- ##GALLEON_EXCLUDED_LAYERS## -->
+                            </excluded-layers>
                         </configuration>
                     </execution>
                 </executions>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_provisioning/pom.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_provisioning/pom.xml
@@ -39,24 +39,21 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>${s2i.provisioning.maven.plugin.groupId}</groupId>
+                <artifactId>${s2i.provisioning.maven.plugin.artifactId}</artifactId>
                 <executions>
                     <execution>
                         <id>provision a provisioning.xml file</id>
                         <goals>
-                            <goal>provision-file</goal>
+                            <goal>package</goal>
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/server</install-dir>
-                            <record-state>true</record-state>
-                            <offline>false</offline>
-                            <plugin-options>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <galleon-options>
                                 <!-- required when running on JDK 11 -->
                                 <jboss-fork-embedded>true</jboss-fork-embedded>
-                            </plugin-options>
-                            <provisioningFile>provisioning.xml</provisioningFile>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/pom.xml
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/provisioning/pom.xml
@@ -34,7 +34,9 @@
         </license>
     </licenses>
     <properties>
-        <version.org.jboss.galleon>${env.GALLEON_VERSION}</version.org.jboss.galleon>
+        <s2i.provisioning.maven.plugin.artifactId>${env.PROVISIONING_MAVEN_PLUGIN_ARTIFACT_ID}</s2i.provisioning.maven.plugin.artifactId>
+        <s2i.provisioning.maven.plugin.groupId>${env.PROVISIONING_MAVEN_PLUGIN_GROUP_ID}</s2i.provisioning.maven.plugin.groupId>
+        <version.s2i.provisioning.maven.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.s2i.provisioning.maven.plugin>
     </properties>
     <modules>
         <module>generic_layers</module>
@@ -45,9 +47,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.jboss.galleon</groupId>
-                    <artifactId>galleon-maven-plugin</artifactId>
-                    <version>${version.org.jboss.galleon}</version>
+                    <groupId>${s2i.provisioning.maven.plugin.groupId}</groupId>
+                    <artifactId>${s2i.provisioning.maven.plugin.artifactId}</artifactId>
+                    <version>${version.s2i.provisioning.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
@@ -3,17 +3,22 @@ GALLEON_DEFAULT_DEFINITION="$JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE"/
 GALLEON_GENERIC_PROVISIONING_DEFINITION="$JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE"/provisioning/generic_provisioning
 
 function galleon_patch_generic_config() {
+   included_layers=
+   excluded_layers=
    if [ -n "$GALLEON_PROVISION_LAYERS" ]; then
      for layer in $(echo $GALLEON_PROVISION_LAYERS | sed "s/,/ /g"); do
        if [[ "$layer" =~ ^-.* ]]; then
          layer="${layer:1}"
-         layers="$layers<exclude name=\"$layer\"/>"
+         excluded_layers="$excluded_layers<layer> $layer</layer>"
        else
-         layers="$layers<include name=\"$layer\"/>"
+         included_layers="$included_layers<layer> $layer</layer>"
        fi
      done
-     if [ -n "$layers" ]; then
-       sed -i "s|<!-- ##GALLEON_LAYERS## -->|${layers}|" $GALLEON_GENERIC_LAYERS_DEFINITION/config.xml
+     if [ -n "$included_layers" ]; then
+       sed -i "s|<!-- ##GALLEON_INCLUDED_LAYERS## -->|${included_layers}|" $GALLEON_GENERIC_LAYERS_DEFINITION/pom.xml
+     fi
+     if [ -n "$excluded_layers" ]; then
+       sed -i "s|<!-- ##GALLEON_EXCLUDED_LAYERS## -->|${excluded_layers}|" $GALLEON_GENERIC_LAYERS_DEFINITION/pom.xml
      fi
    fi
    if [ -n "$GALLEON_PROVISION_FEATURE_PACKS" ]; then
@@ -29,7 +34,21 @@ function galleon_patch_generic_config() {
 }
 
 function galleon_patch_default_config() {
-   sed -i "s|<!-- ##GALLEON_FEATURE_PACK## -->|${1}|" $GALLEON_DEFAULT_DEFINITION/pom.xml
+  # default config, use the latest fp default configs.
+  feature_packs_content=
+  fps_array=()
+  for fp in $(echo "${GALLEON_PROVISION_FEATURE_PACKS}" | sed "s/,/ /g"); do
+    fps_array+=($fp)
+  done
+  lastIndex=$((${#fps_array[@]} -1))
+  for index in "${!fps_array[@]}"; do
+    inherit_configs="false";
+    if [ $index == $lastIndex ]; then
+      inherit_configs="true";
+    fi
+    feature_packs_content="$feature_packs_content<feature-pack><location>${fps_array[$index]}</location><inherit-packages>true</inherit-packages><inherit-configs>$inherit_configs</inherit-configs></feature-pack>"
+  done
+  sed -i "s|<!-- ##GALLEON_FEATURE_PACKS## -->|${feature_packs_content}|" $GALLEON_DEFAULT_DEFINITION/pom.xml
 }
 
 function galleon_init_mvn_env() {
@@ -137,17 +156,7 @@ function galleon_provision_server() {
       fi
     else
       if [ -n "$GALLEON_PROVISION_FEATURE_PACKS" ]; then
-        # default config, only 1 FP expected.
-        nb=0
-        for fp in $(echo "${GALLEON_PROVISION_FEATURE_PACKS}" | sed "s/,/ /g"); do
-          nb=$((nb+1))
-          main_fp=$fp
-        done
-        if [ $nb -gt 1 ]; then
-          log_error "Error, more than one feature-pack provided in GALLEON_PROVISION_FEATURE_PACKS, can't provision default config."
-          exit 1
-        fi
-        galleon_patch_default_config $main_fp
+        galleon_patch_default_config
         GALLEON_DESCRIPTION_LOCATION="$GALLEON_DEFAULT_DEFINITION"
         if [ -n "${GALLEON_USE_LOCAL_FILE}" ] && [ -f $GALLEON_LOCAL_PROVISIONING/provisioning.xml ]; then
           log_warning "Galleon provisioning of default config overrides Galleon provisioning.xml located in $GALLEON_LOCAL_PROVISIONING"
@@ -155,7 +164,8 @@ function galleon_provision_server() {
       else
         if [ -n "${GALLEON_USE_LOCAL_FILE}" ] && [ -f "$GALLEON_LOCAL_PROVISIONING/provisioning.xml" ]; then
           log_info "Provisioning server with Galleon description in $GALLEON_LOCAL_PROVISIONING"
-          cp "$GALLEON_LOCAL_PROVISIONING/provisioning.xml" "$GALLEON_GENERIC_PROVISIONING_DEFINITION"
+          mkdir -p "$GALLEON_GENERIC_PROVISIONING_DEFINITION"/galleon
+          cp "$GALLEON_LOCAL_PROVISIONING/provisioning.xml" "$GALLEON_GENERIC_PROVISIONING_DEFINITION"/galleon
           GALLEON_DESCRIPTION_LOCATION="$GALLEON_GENERIC_PROVISIONING_DEFINITION"
         else
           log_error "No provisioning.xml file exists in $GALLEON_LOCAL_PROVISIONING, invalid galleon configuration."

--- a/jboss/container/wildfly/s2i/legacy/module.yaml
+++ b/jboss/container/wildfly/s2i/legacy/module.yaml
@@ -8,8 +8,12 @@ envs:
   value: "/opt/jboss/container/wildfly/s2i/galleon"
 - name: S2I_SOURCE_DEPLOYMENTS_FILTER
   value: "*.war *.ear *.rar *.jar"
-- name: GALLEON_VERSION
-  value: "4.2.8.Final"
+- name: PROVISIONING_MAVEN_PLUGIN_ARTIFACT_ID
+  value: "wildfly-maven-plugin"
+- name: PROVISIONING_MAVEN_PLUGIN_GROUP_ID
+  value: "org.wildfly.plugins"
+- name: PROVISIONING_MAVEN_PLUGIN_VERSION
+  value: "3.0.0.Alpha2"
 - name: GALLEON_CUSTOM_FEATURE_PACKS_MAVEN_REPO
   description: "DEPRECATED API. Absolute path to a maven repo directory containing custom galleon feature-packs. By default the directory 'galleon/repository' is used."
 - name: GALLEON_DIR


### PR DESCRIPTION
* Replace usage of galleon maven plugin by the usage of WildFly Maven plugin for legacy provisioning.
* Allow for multiple feature-packs when generating the default configuration. the latest FP being used to provide default configuration(s).