### PR TITLE
Fix for Issue #279, Keystore type shouldn't be mandatory when generating HTTPS configuration using elytron

### DIFF
--- a/jboss/container/wildfly/launch/elytron/test/elytron.bats
+++ b/jboss/container/wildfly/launch/elytron/test/elytron.bats
@@ -2,7 +2,7 @@
 # dont enable these by default, bats on CI doesn't output anything if they are set
 # set -euo pipefail
 # IFS=$'\n\t'
-
+source $BATS_TEST_DIRNAME/../../../../../../test-common/cli_utils.sh
 export BATS_TEST_SKIPPED=
 export JBOSS_HOME=$BATS_TMPDIR/jboss_home
 
@@ -296,7 +296,7 @@ EOF
     run configure_https
     echo "OUTPUT ${output}"
     [ "${output}" = "WARN CONFIGURE_ELYTRON_SSL env variable is set to true, that is no more needed, SSL can only be configured using Elytron.
-WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_PASSWORD HTTPS_KEYSTORE HTTPS_KEYSTORE_TYPE" ]
+WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_PASSWORD HTTPS_KEYSTORE" ]
 }
 
 @test "Configure HTTPS - set CONFIGURE_ELYTRON_SSL=false" {
@@ -312,7 +312,7 @@ ERROR Exiting..." ]
 @test "Configure HTTPS - missing all required vars" {
     echo '<!-- ##ELYTRON_TLS## -->' > ${CONFIG_FILE}
     echo '<!-- ##TLS## -->' >> ${CONFIG_FILE}
-    expected='WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_PASSWORD HTTPS_KEYSTORE HTTPS_KEYSTORE_TYPE'
+    expected='WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_PASSWORD HTTPS_KEYSTORE'
     HTTPS_PASSWORD=
     HTTPS_KEYSTORE=
     HTTPS_KEYSTORE_TYPE=
@@ -330,20 +330,6 @@ ERROR Exiting..." ]
     HTTPS_PASSWORD=
     HTTPS_KEYSTORE="ks"
     HTTPS_KEYSTORE_TYPE="ks_type"
-    HTTPS_KEY_PASSWORD=
-    HTTPS_KEYSTORE_DIR=
-    run configure_https
-    echo "${output}"
-    [ "${output}" = "${expected}" ]
-}
-
-@test "Configure HTTPS - missing HTTPS_KEYSTORE_TYPE" {
-    echo '<!-- ##ELYTRON_TLS## -->' > ${CONFIG_FILE}
-    echo '<!-- ##TLS## -->' >> ${CONFIG_FILE}
-    expected='WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_KEYSTORE_TYPE'
-    HTTPS_PASSWORD="password"
-    HTTPS_KEYSTORE="ks"
-    HTTPS_KEYSTORE_TYPE=
     HTTPS_KEY_PASSWORD=
     HTTPS_KEYSTORE_DIR=
     run configure_https
@@ -380,6 +366,45 @@ ERROR Exiting..." ]
 }
 
 @test "Configure HTTPS - Basic config" {
+    echo '<?xml version="1.0"?>' > ${CONFIG_FILE}
+    echo '<!-- ##ELYTRON_TLS## -->' >> ${CONFIG_FILE}
+    echo '<!-- ##TLS## -->' >> ${CONFIG_FILE}
+
+expected=$(cat <<EOF
+<?xml version="1.0"?>
+   <tls>
+     <key-stores>
+       <key-store name="LocalhostKeyStore">
+         <credential-reference clear-text="password"/>
+         <file path="keystore.ks" relative-to="jboss.server.config.dir"/>
+       </key-store>
+       <!-- ##ELYTRON_KEY_STORE## -->
+     </key-stores>
+     <key-managers>
+       <key-manager name="LocalhostKeyManager" key-store="LocalhostKeyStore">
+         <credential-reference clear-text="password"/>
+       </key-manager>
+       <!-- ##ELYTRON_KEY_MANAGER## -->
+     </key-managers>
+     <server-ssl-contexts>
+       <server-ssl-context name="LocalhostSslContext" key-manager="LocalhostKeyManager"/>
+       <!-- ##ELYTRON_SERVER_SSL_CONTEXT## -->
+     </server-ssl-contexts>
+   </tls>
+EOF
+)
+    HTTPS_PASSWORD="password"
+    HTTPS_KEYSTORE="keystore.ks"
+    HTTPS_KEY_PASSWORD=
+    HTTPS_KEYSTORE_DIR=
+    run configure_https
+    output=$(cat "${CONFIG_FILE}" | xmllint --format --noblanks -)
+    echo "${output}"
+    expected=$(echo "${expected}" | sed 's|\\n||g' | xmllint --format --noblanks -)
+    [ "${output}" = "${expected}" ]
+}
+
+@test "Configure HTTPS - Basic config with keystore type" {
     echo '<?xml version="1.0"?>' > ${CONFIG_FILE}
     echo '<!-- ##ELYTRON_TLS## -->' >> ${CONFIG_FILE}
     echo '<!-- ##TLS## -->' >> ${CONFIG_FILE}
@@ -687,5 +712,98 @@ EOF
     echo "${output}"
     expected=$(echo "${expected}")
     echo "${expected}"
+    [ "${output}" = "${expected}" ]
+}
+
+@test "Configure HTTPS - CLI Basic config" {
+
+expected=$(cat <<EOF
+      if (outcome == success) of /subsystem=elytron:read-resource
+        /subsystem=elytron/key-store="LocalhostKeyStore":add(credential-reference={clear-text="password"}, path="keystore.ks", relative-to="jboss.server.config.dir")
+      else
+        echo "Cannot configure Elytron Key Store. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
+        quit
+      end-if
+      if (outcome == success) of /subsystem=elytron:read-resource
+        /subsystem=elytron/key-manager="LocalhostKeyManager":add(key-store="LocalhostKeyStore", credential-reference={clear-text="password"})
+      else
+        echo "Cannot configure Elytron Key Manager. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
+      end-if
+      if (outcome == success) of /subsystem=elytron:read-resource
+        /subsystem=elytron/server-ssl-context="LocalhostSslContext":add(key-manager="LocalhostKeyManager")
+      else
+        echo "Cannot configure Elytron Server SSL Context. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
+      end-if
+      for serverName in /subsystem=undertow:read-children-names(child-type=server)
+        if (result == []) of /subsystem=undertow/server=\$serverName:read-children-names(child-type=https-listener)
+          /subsystem=undertow/server=\$serverName/https-listener="https":add(ssl-context="LocalhostSslContext", socket-binding="https", proxy-address-forwarding="true")
+        else
+          echo There is already an undertow https-listener for the '\$serverName' server so we are not adding it >> \${warning_file}
+        end-if
+      done
+
+EOF
+)
+    cp $BATS_TEST_DIRNAME/../../../../../../test-common/configuration/standalone-openshift.xml $JBOSS_HOME/standalone/configuration/standalone-openshift.xml
+    CONFIG_FILE=$JBOSS_HOME/standalone/configuration/standalone-openshift.xml
+    CONFIG_ADJUSTMENT_MODE="cli"
+
+    HTTPS_PASSWORD="password"
+    HTTPS_KEYSTORE="keystore.ks"
+    HTTPS_KEY_PASSWORD=
+    HTTPS_KEYSTORE_DIR=
+    run configure_https
+    echo "CONSOLE:${output}"
+    output=$(cat "${CLI_SCRIPT_FILE}")
+    normalize_spaces_new_lines
+    echo "${output}" > /tmp/output.txt
+    echo "${expected}" > /tmp/expected.txt
+    [ "${output}" = "${expected}" ]
+}
+
+@test "Configure HTTPS - CLI Basic config with keystore type" {
+
+expected=$(cat <<EOF
+      if (outcome == success) of /subsystem=elytron:read-resource
+        /subsystem=elytron/key-store="LocalhostKeyStore":add(credential-reference={clear-text="password"}, path="keystore.ks", type="PKCS12", relative-to="jboss.server.config.dir")
+      else
+        echo "Cannot configure Elytron Key Store. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
+        quit
+      end-if
+      if (outcome == success) of /subsystem=elytron:read-resource
+        /subsystem=elytron/key-manager="LocalhostKeyManager":add(key-store="LocalhostKeyStore", credential-reference={clear-text="password"})
+      else
+        echo "Cannot configure Elytron Key Manager. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
+      end-if
+      if (outcome == success) of /subsystem=elytron:read-resource
+        /subsystem=elytron/server-ssl-context="LocalhostSslContext":add(key-manager="LocalhostKeyManager")
+      else
+        echo "Cannot configure Elytron Server SSL Context. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
+      end-if
+      for serverName in /subsystem=undertow:read-children-names(child-type=server)
+        if (result == []) of /subsystem=undertow/server=\$serverName:read-children-names(child-type=https-listener)
+          /subsystem=undertow/server=\$serverName/https-listener="https":add(ssl-context="LocalhostSslContext", socket-binding="https", proxy-address-forwarding="true")
+        else
+          echo There is already an undertow https-listener for the '\$serverName' server so we are not adding it >> \${warning_file}
+        end-if
+      done
+
+EOF
+)
+    cp $BATS_TEST_DIRNAME/../../../../../../test-common/configuration/standalone-openshift.xml $JBOSS_HOME/standalone/configuration/standalone-openshift.xml
+    CONFIG_FILE=$JBOSS_HOME/standalone/configuration/standalone-openshift.xml
+    CONFIG_ADJUSTMENT_MODE="cli"
+
+    HTTPS_PASSWORD="password"
+    HTTPS_KEYSTORE="keystore.ks"
+    HTTPS_KEYSTORE_TYPE=PKCS12
+    HTTPS_KEY_PASSWORD=
+    HTTPS_KEYSTORE_DIR=
+    run configure_https
+    echo "CONSOLE:${output}"
+    output=$(cat "${CLI_SCRIPT_FILE}")
+    normalize_spaces_new_lines
+    echo "${output}" > /tmp/output.txt
+    echo "${expected}" > /tmp/expected.txt
     [ "${output}" = "${expected}" ]
 }

--- a/jboss/container/wildfly/launch/elytron/test/security-domains.bats
+++ b/jboss/container/wildfly/launch/elytron/test/security-domains.bats
@@ -42,7 +42,7 @@ teardown() {
 
   run configure
   echo "${output}"
-  [ "${output}" = "WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_PASSWORD HTTPS_KEYSTORE HTTPS_KEYSTORE_TYPE
+  [ "${output}" = "WARN Partial HTTPS configuration, the https connector WILL NOT be configured. Missing: HTTPS_PASSWORD HTTPS_KEYSTORE
 ERROR SECDOMAIN_NAME env variable can't be set, use ELYTRON_SECDOMAIN_NAME env variable to configure authentication using Elytron.
 ERROR Exiting..." ]
 }

--- a/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
@@ -240,10 +240,10 @@ validate_keystore_and_create() {
 
   if [ "${valid_state}" = "valid" ]; then
     if [ "${mode}" = "xml" ]; then
-      key_store=$(create_elytron_keystore "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      key_store=$(create_elytron_keystore "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE:-JCEKS}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
       jgroups_encrypt=$(create_jgroups_elytron_encrypt "${protocol}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}")
     elif [ "${mode}" = "cli" ]; then
-      key_store=$(create_elytron_keystore_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      key_store=$(create_elytron_keystore_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE:-JCEKS}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
       jgroups_encrypt=$(create_jgroups_elytron_encrypt_cli "${protocol}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}")
     fi
   fi

--- a/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
+++ b/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
@@ -349,7 +349,7 @@ EOF
 @test "Configure CLI JGROUPS_PROTOCOL=ASYM_ENCRYPT with Elytron" {
   expected=$(cat <<EOF
     if (outcome == success) of /subsystem=elytron:read-resource
-      /subsystem=elytron/key-store="jgroups.jceks":add(credential-reference={clear-text="p@ssw0rd"},type="JCEKS",path="jgroups.jceks", relative-to="jboss.server.config.dir")
+      /subsystem=elytron/key-store="jgroups.jceks":add(credential-reference={clear-text="p@ssw0rd"}, path="jgroups.jceks", type="JCEKS", relative-to="jboss.server.config.dir")
     else
       echo "Cannot configure Elytron Key Store. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
       quit
@@ -404,7 +404,7 @@ EOF
 @test "Configure CLI JGROUPS_PROTOCOL=SYM_ENCRYPT - Using Elytron to configure the keystore" {
     expected=$(cat <<EOF
       if (outcome == success) of /subsystem=elytron:read-resource
-         /subsystem=elytron/key-store="encrypt_keystore":add(credential-reference={clear-text="encrypt_password"},type="JCEKS",path="encrypt_keystore", relative-to="keystore_dir")
+         /subsystem=elytron/key-store="encrypt_keystore":add(credential-reference={clear-text="encrypt_password"}, path="encrypt_keystore", type="JCEKS", relative-to="keystore_dir")
        else
          echo "Cannot configure Elytron Key Store. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
          quit


### PR DESCRIPTION
* Allow for HTTPS_KEYSTORE_TYPE to be not set. Do not set a type, let elytron handle the keystore type.
* Added new unit tests
* Changed warning message.
* JCEKS is still the default for JGroups encryption.