### PR TITLE
Fix for WFWIP-432, Improve binary build experience for server mode

### DIFF
--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
@@ -4,6 +4,7 @@ source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
 
 # include our overrides/extensions
 source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/s2i-core-hooks"
+source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/maven-s2i-overrides"
 
 # invoke the build
 maven_s2i_build

--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/disabled-copy-hooks
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/disabled-copy-hooks
@@ -1,0 +1,6 @@
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+function s2i_core_copy_artifacts_hook() {
+ # NO-OP.
+ log_info "No custom content to copy, binary content contains only a server root directory"
+}

--- a/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/maven-s2i-overrides
+++ b/jboss/container/wildfly/s2i/bash/artifacts/opt/jboss/container/wildfly/s2i/maven-s2i-overrides
@@ -1,0 +1,22 @@
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+function maven_s2i_custom_binary_build() {
+  local serverDir="${S2I_SOURCE_DIR}/${S2I_SERVER_DIR:-server}"
+  if [ -d "${serverDir}" ]; then
+    log_info "S2I binary build, found server ${serverDir}"
+    log_info "Copying server from $serverDir to $JBOSS_HOME..."
+    cp -r "$serverDir" "$JBOSS_HOME"
+  else
+     log_info "S2I binary build, ${serverDir} not found, root dir must be a server home directory."
+     if [ -f "${S2I_SOURCE_DIR}/jboss-modules.jar" ] && [ -d "${S2I_SOURCE_DIR}/modules" ]; then
+       log_info "S2I binary build, server home detected, installing server."
+       cp -r "${S2I_SOURCE_DIR}" "$JBOSS_HOME"
+       # No copy can be operated in next steps, the binary content is only the server content. 
+       source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/disabled-copy-hooks"
+     else
+      log_error "Not a server home directory, exiting."
+      exit 1
+     fi
+  fi
+  chmod -R ug+rwX $JBOSS_HOME
+} 

--- a/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
+++ b/jboss/container/wildfly/s2i/legacy/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
@@ -31,6 +31,7 @@ if [ -n "${GALLEON_PROVISION_FEATURE_PACKS}" ] || [ -n "${GALLEON_USE_LOCAL_FILE
 else
   # include our overrides/extensions
   source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/s2i-core-hooks"
+  source "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/maven-s2i-overrides"
 fi
 # invoke the build
 maven_s2i_build


### PR DESCRIPTION
* Detect special case of a directory being a server directory. Disable any copy of custom content, there are no, just a server.