### PR TITLE
Fix for Issue #320, [JDK17] Missing modular export when enabling dns ping protocol

### DIFF
--- a/jboss/container/wildfly/run/api/module.yaml
+++ b/jboss/container/wildfly/run/api/module.yaml
@@ -4,25 +4,27 @@ version: '1.0'
 description: Env variable to configure the server for cloud execution. JVM is automatically configured, all Java VM related env variables are supported.
 
 envs:
-- name: JAVA_OPTS_APPEND
-  description: To append options to JAVA_OPTS env variable.
-- name: CLI_LAUNCH_SCRIPT
-  description: A path to a CLI script to execute at server launch time. The path can be absolute or relative to $JBOSS_HOME directory. If an error occurs during script execution, the server startup aborts and CLI errors are displayed in the console. Management operations that imply a restart of the server are not supported in such CLI script.
 - name: CLI_EXECUTION_OUTPUT
   description: By default executed CLI script output is redirected to '/tmp/server-cli-execution-output-file.txt' file (or '/tmp/cli-script-output-<system-time>.cli' when cloud feature-pack is used). Set this env variable to 'CONSOLE' for output to be displayed in the console. Set this env variable to a file path for output to be redirected in the provided file.
-- name: PORT_OFFSET
-  description: Use this env variable to set the server port offset. This is advised practice instead of directly setting jboss.socket.binding.port-offset in the SERVER_ARGS. It allows the server shutdown logic to connect to the running server to do a clean CLI shutdown. 
 - name: CLI_GRACEFUL_SHUTDOWN
   description: Set this variable to true to disable server shutdown. You are then in charge to explicitly kill the server by your own mean.
+- name: CLI_LAUNCH_SCRIPT
+  description: A path to a CLI script to execute at server launch time. The path can be absolute or relative to $JBOSS_HOME directory. If an error occurs during script execution, the server startup aborts and CLI errors are displayed in the console. Management operations that imply a restart of the server are not supported in such CLI script.
+- name: JAVA_OPTS_APPEND
+  description: To append options to JAVA_OPTS env variable.
 - name: JBOSS_NODE_NAME
   description: Set jboss.node.name property value. By default a truncated to 23 characters name based on the hostname is computed.
+- name: PORT_OFFSET
+  description: Use this env variable to set the server port offset. This is advised practice instead of directly setting jboss.socket.binding.port-offset in the SERVER_ARGS. It allows the server shutdown logic to connect to the running server to do a clean CLI shutdown. 
+- name: RUN_SCRIPT_JPMS_ADD_EXPORT_JNDI_DNS
+  description: On JDK15+, the --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED option is added. Set this env to false to disable it. 
 - name: SERVER_ARGS
   description: In order to provide arguments to the launched server.
 - name: SERVER_ENABLE_STATISTICS
   description: True by default. That is the value passed to '-Dwildfly.statistics-enabled' system property when launching the server. Set it to 'false' to disable statistics.
-- name: SERVER_PUBLIC_BIND_ADDRESS
-  description: By default the public interface is bound to the hostname ip address. You can change this default using this env variable.
-- name: SERVER_MANAGEMENT_BIND_ADDRESS
-  description: By default the public interface is bound to 0:0:0:0 address. You can change this default using this env variable.
 - name: SERVER_LAUNCH_SCRIPT_OVERRIDE
   description: In order to override the server launch script called by the image entry-point, set this env variable to the name of a bash file located in the '$JBOSS_HOME/bin' directory.
+- name: SERVER_MANAGEMENT_BIND_ADDRESS
+  description: By default the public interface is bound to 0:0:0:0 address. You can change this default using this env variable.
+- name: SERVER_PUBLIC_BIND_ADDRESS
+  description: By default the public interface is bound to the hostname ip address. You can change this default using this env variable.

--- a/jboss/container/wildfly/run/bash/artifacts/opt/jboss/container/wildfly/run/run
+++ b/jboss/container/wildfly/run/bash/artifacts/opt/jboss/container/wildfly/run/run
@@ -1,40 +1,16 @@
 #!/bin/bash
 
 source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_WILDFLY_RUN_MODULE}/run-utils.sh"
 
 if [ ! -d "${JBOSS_HOME}" ]; then
     log_error "*** No installed Server, exiting ***"
     exit 1
 fi
 
-# Logic to allow for CLI shutdown with a 60secs delay that helps transaction to terminate 
-function clean_shutdown() {
-  local management_port=""
-  if [ -n "${PORT_OFFSET}" ]; then
-    management_port=$((9990 + PORT_OFFSET))
-  fi
-  log_error "*** WildFly wrapper process ($$) received TERM signal ***"
-  if [ -z ${management_port} ]; then
-    $JBOSS_HOME/bin/jboss-cli.sh -c "shutdown --timeout=60"
-  else
-    $JBOSS_HOME/bin/jboss-cli.sh --commands="connect remote+http://localhost:${management_port},shutdown --timeout=60"
-  fi
-  wait $!
-}
+run_add_jpms_options
 
-function setupShutdownHook() {
-  trap "clean_shutdown" TERM
-  trap "clean_shutdown" INT
-
-  if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
-    trap "" TERM
-    log_info "Using CLI Graceful Shutdown instead of TERM signal"
-  fi
-}
-
-setupShutdownHook
-
-# END SHUTDOWN LOGIC
+run_setup_shutdown_hook
 
 #Detects launcher.
 if [ -n "${SERVER_LAUNCH_SCRIPT_OVERRIDE}" ]; then
@@ -60,25 +36,6 @@ else
     imgVersion=${JBOSS_IMAGE_VERSION:-$IMAGE_VERSION}
 
     log_info "Running $imgName image, version $imgVersion"
-
-    function init_node_name() {
-      if [ -z "${JBOSS_NODE_NAME}" ] ; then
-        if [ -n "${NODE_NAME}" ]; then
-          JBOSS_NODE_NAME="${NODE_NAME}"
-        elif [ -n "${container_uuid}" ]; then
-          JBOSS_NODE_NAME="${container_uuid}"
-        elif [ -n "${HOSTNAME}" ]; then
-          JBOSS_NODE_NAME="${HOSTNAME}"
-        else
-           JBOSS_NODE_NAME="$(hostname)"
-        fi
-
-        # CLOUD-427: truncate to 23 characters max (from the end backwards)
-        if [ ${#JBOSS_NODE_NAME} -gt 23 ]; then
-          JBOSS_NODE_NAME=${JBOSS_NODE_NAME: -23}
-        fi
-      fi
-    }
 
     # HANDLE JAVA OPTIONS
     source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
@@ -133,7 +90,7 @@ else
     ENABLE_STATISTICS=${SERVER_ENABLE_STATISTICS:-true}
 
     #Ensure node name (FOR NOW NEEDED PERHAPS REVISIT FOR EAP8)
-    init_node_name
+    run_init_node_name
 
     SERVER_ARGS="${JAVA_PROXY_OPTIONS} -Djboss.node.name=${JBOSS_NODE_NAME} ${PORT_OFFSET_PROPERTY} -b ${PUBLIC_IP_ADDRESS} -bmanagement ${MANAGEMENT_IP_ADDRESS} -Dwildfly.statistics-enabled=${ENABLE_STATISTICS} ${SERVER_ARGS}"
 

--- a/jboss/container/wildfly/run/bash/artifacts/opt/jboss/container/wildfly/run/run-utils.sh
+++ b/jboss/container/wildfly/run/bash/artifacts/opt/jboss/container/wildfly/run/run-utils.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+# Some JPMS arguments are specific to cloud, handle them in the main launcher.
+# $JBOSS_HOME/bin/standalone.conf extends JAVA_OPTS with arguments.
+function run_add_java_options() {
+  local marker="${1}"
+  local options="${2}"
+  local conf_file="$JBOSS_HOME/bin/standalone.conf"
+  if ! grep -q "$marker" "$conf_file"; then
+    local jvm_options="$marker
+JAVA_OPTS=\"\$JAVA_OPTS ${options}\""
+    echo "$jvm_options" >> "$conf_file"
+  fi
+}
+
+function run_add_jpms_options() {
+  # Append cloud specific modular options in standalone.conf
+  SPEC_VERSION="${JAVA_VERSION//1.}"
+  SPEC_VERSION="${SPEC_VERSION//.*}"
+  if (( $SPEC_VERSION > 15 )); then
+    MODULAR_JVM_OPTIONS=`echo $JAVA_OPTS | grep "\-\-add\-modules"`
+    if [ "x$MODULAR_JVM_OPTIONS" = "x" ]; then
+      if [ "x$RUN_SCRIPT_JPMS_ADD_EXPORT_JNDI_DNS" == "x" ] || [ "x$RUN_SCRIPT_JPMS_ADD_EXPORT_JNDI_DNS" == "xtrue" ]; then
+        local option="--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
+        local marker="#JVM modular option  ${option} added by image run startup script"
+        run_add_java_options "${marker}" "${option}"
+      fi
+    fi
+  fi
+}
+
+# Logic to allow for CLI shutdown with a 60secs delay that helps transaction to terminate 
+function run_clean_shutdown() {
+  local management_port=""
+  if [ -n "${PORT_OFFSET}" ]; then
+    management_port=$((9990 + PORT_OFFSET))
+  fi
+  log_error "*** WildFly wrapper process ($$) received TERM signal ***"
+  if [ -z ${management_port} ]; then
+    $JBOSS_HOME/bin/jboss-cli.sh -c "shutdown --timeout=60"
+  else
+    $JBOSS_HOME/bin/jboss-cli.sh --commands="connect remote+http://localhost:${management_port},shutdown --timeout=60"
+  fi
+  wait $!
+}
+
+function run_setup_shutdown_hook() {
+  trap "run_clean_shutdown" TERM
+  trap "run_clean_shutdown" INT
+
+  if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
+    trap "" TERM
+    log_info "Using CLI Graceful Shutdown instead of TERM signal"
+  fi
+}
+
+function run_init_node_name() {
+  if [ -z "${JBOSS_NODE_NAME}" ] ; then
+    if [ -n "${NODE_NAME}" ]; then
+      JBOSS_NODE_NAME="${NODE_NAME}"
+    elif [ -n "${container_uuid}" ]; then
+      JBOSS_NODE_NAME="${container_uuid}"
+    elif [ -n "${HOSTNAME}" ]; then
+      JBOSS_NODE_NAME="${HOSTNAME}"
+    else
+      JBOSS_NODE_NAME="$(hostname)"
+    fi
+
+    # CLOUD-427: truncate to 23 characters max (from the end backwards)
+    if [ ${#JBOSS_NODE_NAME} -gt 23 ]; then
+      JBOSS_NODE_NAME=${JBOSS_NODE_NAME: -23}
+    fi
+  fi
+}

--- a/jboss/container/wildfly/run/bash/test/run.bats
+++ b/jboss/container/wildfly/run/bash/test/run.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+source $BATS_TEST_DIRNAME/../../../../../../test-common/cli_utils.sh
+# fake JBOSS_HOME
+export JBOSS_HOME=$BATS_TMPDIR/jboss_home
+rm -rf $JBOSS_HOME 2>/dev/null
+mkdir -p $JBOSS_HOME/bin/
+touch $JBOSS_HOME/bin/standalone.conf
+
+export JBOSS_CONTAINER_UTIL_LOGGING_MODULE=$BATS_TMPDIR/logging
+mkdir -p "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}"
+cp $BATS_TEST_DIRNAME/../../../../../../test-common/logging.sh "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}"
+source $BATS_TEST_DIRNAME/../artifacts/opt/jboss/container/wildfly/run/run-utils.sh
+
+setup() {
+ rm -f $JBOSS_HOME/bin/standalone.conf
+ touch $JBOSS_HOME/bin/standalone.conf
+}
+
+@test "Java 8" {
+  JAVA_VERSION=1.8
+  run run_add_jpms_options
+  [ "${output}" = "" ]
+  confFile=$(<"${JBOSS_HOME}/bin/standalone.conf")
+   [ "${confFile}" = "" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "Java 11" {
+  JAVA_VERSION=11
+  run run_add_jpms_options
+  [ "${output}" = "" ]
+  confFile=$(<"${JBOSS_HOME}/bin/standalone.conf")
+   [ "${confFile}" = "" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "Java 17" {
+  expected=$(cat << EOF
+#JVM modular option  --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED added by image run startup script
+JAVA_OPTS="\$JAVA_OPTS --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
+EOF
+    )
+  JAVA_VERSION=17
+  run run_add_jpms_options
+  output=$(<"${JBOSS_HOME}/bin/standalone.conf")
+  normalize_spaces_new_lines
+  echo "$output"
+  echo "$expected"
+  [ "${output}" = "${expected}" ]
+}
+
+@test "Java 17, jndi export disabled" {
+  RUN_SCRIPT_JPMS_ADD_EXPORT_JNDI_DNS=false
+  JAVA_VERSION=17
+  run run_add_jpms_options
+  [ "${output}" = "" ]
+  confFile=$(<"${JBOSS_HOME}/bin/standalone.conf")
+   [ "${confFile}" = "" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "Java 17, jndi export enabled" {
+  expected=$(cat << EOF
+#JVM modular option  --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED added by image run startup script
+JAVA_OPTS="\$JAVA_OPTS --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
+EOF
+    )
+RUN_SCRIPT_JPMS_ADD_EXPORT_JNDI_DNS=true
+  JAVA_VERSION=17
+  run run_add_jpms_options
+  output=$(<"${JBOSS_HOME}/bin/standalone.conf")
+  normalize_spaces_new_lines
+  echo "$output"
+  echo "$expected"
+  [ "${output}" = "${expected}" ]
+}
+
+@test "JBoss Node name set" {
+  JBOSS_NODE_NAME=foo
+  run_init_node_name
+  [ "${JBOSS_NODE_NAME}" = "foo" ]
+}
+
+@test "Node name set" {
+  NODE_NAME=abcdefghijklmnopqrstuvwxyz
+  run_init_node_name
+  [ "${JBOSS_NODE_NAME}" = "defghijklmnopqrstuvwxyz" ]
+}
+
+@test "Host name set" {
+  HOSTNAME=abcdefghijklmnopqrstuvwxyz123
+  run_init_node_name
+    echo $JBOSS_NODE_NAME
+  [ "${JBOSS_NODE_NAME}" = "ghijklmnopqrstuvwxyz123" ]
+}


### PR DESCRIPTION
* run entrypoint to add the export. Can be disabled thanks to an env variable.
* Refactored run entry points to allow to test some functions.
* Added bats tests for run entrypoint
* Re-ordered API documentation.