### PR TITLE
Fix for Issue #322, if dynamic_resources.sh isn't available the server should still be able to start.

### DIFF
--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/java/added/src/main/resources/packages/wildfly.s2i.java/content/bin/java-conf.conf
@@ -1,19 +1,27 @@
 
-source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
 export GC_METASPACE_SIZE=${GC_METASPACE_SIZE:-96}
 
-JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
-
-# If JAVA_DIAGNOSTICS and there is jvm_specific_diagnostics, move the settings to PREPEND_JAVA_OPTS
-# to bypass the specific EAP checks done on JAVA_OPTS in standalone.sh that could remove the GC EAP specific log configurations
-JVM_SPECIFIC_DIAGNOSTICS=$(jvm_specific_diagnostics)
-if [ "x$JAVA_DIAGNOSTICS" != "x" ] && [ "x{JVM_SPECIFIC_DIAGNOSTICS}" != "x" ]; then
-  JAVA_OPTS=${JAVA_OPTS/${JVM_SPECIFIC_DIAGNOSTICS} /}
-  PREPEND_JAVA_OPTS="${JVM_SPECIFIC_DIAGNOSTICS} ${PREPEND_JAVA_OPTS}"
+if [ -f "/usr/local/dynamic-resources/dynamic_resources.sh" ]; then
+  source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
+  JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
+  # If JAVA_DIAGNOSTICS and there is jvm_specific_diagnostics, move the settings to PREPEND_JAVA_OPTS
+  # to bypass the specific EAP checks done on JAVA_OPTS in standalone.sh that could remove the GC EAP specific log configurations
+  JVM_SPECIFIC_DIAGNOSTICS=$(jvm_specific_diagnostics)
+  if [ "x$JAVA_DIAGNOSTICS" != "x" ] && [ "x{JVM_SPECIFIC_DIAGNOSTICS}" != "x" ]; then
+    JAVA_OPTS=${JAVA_OPTS/${JVM_SPECIFIC_DIAGNOSTICS} /}
+    PREPEND_JAVA_OPTS="${JVM_SPECIFIC_DIAGNOSTICS} ${PREPEND_JAVA_OPTS}"
+  fi
+else
+  echo "WARNING File /usr/local/dynamic-resources/dynamic_resources.sh not found, JVM will be not configured."
 fi
 
-# Make sure that we use /dev/urandom (CLOUD-422)
-JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom"
+
+if [ ! -f "/dev/urandom" ]; then
+  # Make sure that we use /dev/urandom (CLOUD-422)
+  JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom"
+else
+  echo "WARNING File /dev/urandom not found, java.security.egd system property not set."
+fi
 
 # White list packages for use in ObjectMessages: CLOUD-703
 if [ -n "$MQ_SERIALIZABLE_PACKAGES" ]; then


### PR DESCRIPTION
standalone.conf adapts to execution context.