### PR TITLE
Fix for WFWIP-461, Required HTTPS_KEYSTORE_TYPE won't let secured route to be configured

### DIFF
--- a/jboss/container/wildfly/launch/elytron/added/launch/elytron.sh
+++ b/jboss/container/wildfly/launch/elytron/added/launch/elytron.sh
@@ -128,9 +128,13 @@ create_elytron_keystore() {
     fi
 
     local key_store="<key-store name=\"${encrypt_keystore_name}\">\n\
-              <credential-reference clear-text=\"${encrypt_password}\"/>\n\
-              <implementation type=\"${encrypt_keystore_type:-JCEKS}\"/>\n\
-              <file ${keystore_path} ${keystore_rel_to} />\n\
+                    <credential-reference clear-text=\"${encrypt_password}\"/>\n"
+
+    if [ ! "x${encrypt_keystore_type}" = "x" ]; then
+      key_store=$key_store"<implementation type=\"${encrypt_keystore_type}\"/>\n"
+    fi
+
+    key_store=$key_store"<file ${keystore_path} ${keystore_rel_to} />\n\
             </key-store>"
     echo ${key_store}
 }
@@ -157,7 +161,10 @@ create_elytron_keystore_cli() {
     keystore_rel_to="${encrypt_keystore_dir}"
   fi
 
-  local cli_key_store_op="/subsystem=elytron/key-store=\"${encrypt_keystore_name}\":add(credential-reference={clear-text=\"${encrypt_password}\"},type=\"${encrypt_keystore_type:-JCEKS}\",path=\"${keystore_path}\""
+  local cli_key_store_op="/subsystem=elytron/key-store=\"${encrypt_keystore_name}\":add(credential-reference={clear-text=\"${encrypt_password}\"}, path=\"${keystore_path}\""
+  if [ ! "x${encrypt_keystore_type}" = "x" ]; then
+    cli_key_store_op=${cli_key_store_op}", type=\"${encrypt_keystore_type}\""
+  fi
   if [ ! "x${keystore_rel_to}" = "x" ]; then
     cli_key_store_op=${cli_key_store_op}", relative-to=\"${keystore_rel_to}\""
   fi
@@ -279,7 +286,11 @@ configure_https() {
     return
   fi
 
-  if [ -n "${HTTPS_PASSWORD}" -a -n "${HTTPS_KEYSTORE}" -a -n "${HTTPS_KEYSTORE_TYPE}" ]; then
+  if [ -z "${HTTPS_KEYSTORE_TYPE}" ]; then
+    log_warning "No keystore type has been provided, using default keystore type."
+  fi
+
+  if [ -n "${HTTPS_PASSWORD}" -a -n "${HTTPS_KEYSTORE}" ]; then
     if [ -n "${HTTPS_KEY_PASSWORD}" ]; then
       key_password="${HTTPS_KEY_PASSWORD}"
     else
@@ -327,9 +338,6 @@ configure_https() {
     fi
     if [ -z "${HTTPS_KEYSTORE}" ]; then
       missing_msg="$missing_msg HTTPS_KEYSTORE"
-    fi
-    if [ -z "${HTTPS_KEYSTORE_TYPE}" ]; then
-      missing_msg="$missing_msg HTTPS_KEYSTORE_TYPE"
     fi
 
     log_warning "${missing_msg}"

--- a/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
+++ b/jboss/container/wildfly/launch/jgroups/added/launch/jgroups.sh
@@ -245,10 +245,10 @@ validate_keystore_and_create() {
 
   if [ "${valid_state}" = "valid" ]; then
     if [ "${mode}" = "xml" ]; then
-      key_store=$(create_elytron_keystore "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      key_store=$(create_elytron_keystore "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE:-JCEKS}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
       jgroups_encrypt=$(create_jgroups_elytron_encrypt "${protocol}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}")
     elif [ "${mode}" = "cli" ]; then
-      key_store=$(create_elytron_keystore_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
+      key_store=$(create_elytron_keystore_cli "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_PASSWORD}" "${JGROUPS_ENCRYPT_KEYSTORE_TYPE:-JCEKS}" "${JGROUPS_ENCRYPT_KEYSTORE_DIR}")
       jgroups_encrypt=$(create_jgroups_elytron_encrypt_cli "${protocol}" "${JGROUPS_ENCRYPT_KEYSTORE}" "${JGROUPS_ENCRYPT_NAME}" "${JGROUPS_ENCRYPT_PASSWORD}")
     fi
   fi

--- a/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
+++ b/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
@@ -357,7 +357,7 @@ EOF
 @test "Configure CLI JGROUPS_PROTOCOL=ASYM_ENCRYPT with Elytron" {
   expected=$(cat <<EOF
     if (outcome == success) of /subsystem=elytron:read-resource
-      /subsystem=elytron/key-store="jgroups.jceks":add(credential-reference={clear-text="p@ssw0rd"},type="JCEKS",path="jgroups.jceks", relative-to="jboss.server.config.dir")
+      /subsystem=elytron/key-store="jgroups.jceks":add(credential-reference={clear-text="p@ssw0rd"}, path="jgroups.jceks", type="JCEKS", relative-to="jboss.server.config.dir")
     else
       echo "Cannot configure Elytron Key Store. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
       quit
@@ -412,7 +412,7 @@ EOF
 @test "Configure CLI JGROUPS_PROTOCOL=SYM_ENCRYPT - Using Elytron to configure the keystore" {
     expected=$(cat <<EOF
       if (outcome == success) of /subsystem=elytron:read-resource
-         /subsystem=elytron/key-store="encrypt_keystore":add(credential-reference={clear-text="encrypt_password"},type="JCEKS",path="encrypt_keystore", relative-to="keystore_dir")
+         /subsystem=elytron/key-store="encrypt_keystore":add(credential-reference={clear-text="encrypt_password"}, path="encrypt_keystore", type="JCEKS", relative-to="keystore_dir")
        else
          echo "Cannot configure Elytron Key Store. The Elytron subsystem is not present in the server configuration file." >> \${error_file}
          quit


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFWIP-461
Make the keystore type optional.