### PR TITLE
Fix for Issue #335, add support for ENV_FILES for launch scripts that can support it

### DIFF
--- a/jboss/container/wildfly/launch/access-log-valve/added/launch/access_log_valve.sh
+++ b/jboss/container/wildfly/launch/access-log-valve/added/launch/access_log_valve.sh
@@ -31,6 +31,15 @@
 
 source $JBOSS_HOME/bin/launch/logging.sh
 
+function prepareEnv() {
+  unset ENABLE_ACCESS_LOG
+  unset ENABLE_ACCESS_LOG_TRACE
+}
+
+function configureEnv() {
+  configure
+}
+
 function configure() {
   configure_access_log_valve
   configure_access_log_handler

--- a/jboss/container/wildfly/launch/deployment-scanner/added/launch/deploymentScanner.sh
+++ b/jboss/container/wildfly/launch/deployment-scanner/added/launch/deploymentScanner.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+function prepareEnv() {
+  unset AUTO_DEPLOY_EXPLODED
+}
+
+function configureEnv() {
+  configure
+}
+
 function configure() {
   configure_deployment_scanner
 }

--- a/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
+++ b/jboss/container/wildfly/launch/json-logging/added/launch/json_logging.sh
@@ -1,3 +1,12 @@
+#!/bin/sh
+
+function prepareEnv() {
+  unset ENABLE_JSON_LOGGING
+}
+
+function configureEnv() {
+  configure
+}
 
 function configure() {
   configure_json_logging

--- a/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
+++ b/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
@@ -33,6 +33,10 @@ function prepareEnv() {
   unset SSO_USERNAME
 }
 
+function configureEnv() {
+  configure
+}
+
 function configure() {
   if [ ! -n "$SSO_USE_LEGACY" ] || [ "$SSO_USE_LEGACY" != "true" ]; then
     return

--- a/jboss/container/wildfly/launch/messaging/2.0/added/launch/messaging.sh
+++ b/jboss/container/wildfly/launch/messaging/2.0/added/launch/messaging.sh
@@ -55,6 +55,10 @@ function prepareEnv() {
   unset MQ_SERVICE_PREFIX_MAPPING
 }
 
+function configureEnv() {
+  configure
+}
+
 function configure() {
   configure_artemis_address
   inject_brokers

--- a/jboss/container/wildfly/launch/mp-config/added/launch/mp-config.sh
+++ b/jboss/container/wildfly/launch/mp-config/added/launch/mp-config.sh
@@ -1,3 +1,14 @@
+#!/bin/sh
+
+function prepareEnv() {
+  unset MICROPROFILE_CONFIG_DIR
+  unset MICROPROFILE_CONFIG_DIR_ORDINAL
+}
+
+function configureEnv() {
+  configure
+}
+
 configure() {
   configure_microprofile_config_source
 }

--- a/jboss/container/wildfly/launch/oidc/added/oidc.sh
+++ b/jboss/container/wildfly/launch/oidc/added/oidc.sh
@@ -29,6 +29,10 @@ function prepareEnv() {
   oidc_keycloak_prepareEnv
 }
 
+function configureEnv() {
+  configure
+}
+
 function configure() {
   oidc_configure
 }

--- a/jboss/container/wildfly/launch/tracing/added/launch/tracing.sh
+++ b/jboss/container/wildfly/launch/tracing/added/launch/tracing.sh
@@ -1,4 +1,12 @@
-# only processes a single environment as the placeholder is not preserved
+#!/bin/sh
+
+function prepareEnv() {
+  unset WILDFLY_TRACING_ENABLED
+}
+
+function configureEnv() {
+  configure
+}
 
 configure() {
   local configureExtensionMode


### PR DESCRIPTION
Update launch scripts that can be configured from ENV_FILES. 
This PR will be NOT opened against 0.23.x branch, only applied to WF26+. 
We stay on the safe side and only fix in 0.23.x reported bugs.