### PR TITLE
Set WILDFLY_OVERRIDING_ENV_VARS env var

### DIFF
--- a/jboss/container/wildfly/run/bash/module.yaml
+++ b/jboss/container/wildfly/run/bash/module.yaml
@@ -6,6 +6,8 @@ description: Run server in the cloud.
 envs:
 - name: JBOSS_CONTAINER_WILDFLY_RUN_MODULE
   value: /opt/jboss/container/wildfly/run
+- name: WILDFLY_OVERRIDING_ENV_VARS
+  value: "1"
   
 execute:
 - script: configure.sh


### PR DESCRIPTION
This activates the ability to override management attribute values using
environment variables as described in
https://github.com/wildfly/wildfly-proposals/blob/main/management/WFCORE-5489_override_attribute_value_from_env_var.adoc.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>