### PR TITLE
Fix for #346, JGROUPS_ENCRYPT_SECRET is now useless

### DIFF
--- a/jboss/container/wildfly/launch/jgroups/module.yaml
+++ b/jboss/container/wildfly/launch/jgroups/module.yaml
@@ -17,7 +17,7 @@ envs:
     description: Password used to authenticate the node so it is allowed to join the JGroups cluster. Required, when using ASYM_ENCRYPT JGroups cluster traffic encryption protocol. If not set, authentication is disabled, cluster communication is not encrypted and a warning is issued. Optional, when using SYM_ENCRYPT JGroups cluster traffic encryption protocol.
   - name: "JGROUPS_ENCRYPT_KEYSTORE"
     example: "jgroups.jceks"
-    description: Name of the keystore file within the secret specified via JGROUPS_ENCRYPT_SECRET variable. If it is not set when using SYM_ENCRYPT JGroups cluster traffic encryption protocol, the cluster communication is not encrypted and a warning is issued. If it is not set when using ASYM_ENCRYPT JGroups cluster traffic encryption protocol, the cluster communication is encrypted without using Elytron keystore.
+    description: Name of the keystore file. If it is not set when using SYM_ENCRYPT JGroups cluster traffic encryption protocol, the cluster communication is not encrypted and a warning is issued. If it is not set when using ASYM_ENCRYPT JGroups cluster traffic encryption protocol, the cluster communication is encrypted without using Elytron keystore.
   - name: "JGROUPS_ENCRYPT_KEYSTORE_DIR"
     example: "/etc/jgroups-encrypt-secret-volume"
     description: Optional. A non absolute directory path of the keystore file within the secret specified via JGROUPS_ENCRYPT_SECRET variable. If it is not set, then the keystore file is relative to the servers ${jboss.server.config.dir}
@@ -30,9 +30,6 @@ envs:
   - name: "JGROUPS_ENCRYPT_PROTOCOL"
     example: "SYM_ENCRYPT"
     description: JGroups protocol to use for encryption of cluster traffic. Can be either SYM_ENCRYPT or ASYM_ENCRYPT. Defaults to SYM_ENCRYPT.
-  - name: "JGROUPS_ENCRYPT_SECRET"
-    example: "app-secret"
-    description: Name of the secret, containing the JGroups keystore file used for securing the JGroups communications. If it is not set when using SYM_ENCRYPT JGroups cluster traffic encryption protocol, the cluster communication is not encrypted and a warning is issued. If it is not set when using ASYM_ENCRYPT JGroups cluster traffic encryption protocol, the cluster communication is encrypted without using Elytron keystore.
   - name: "JGROUPS_PING_PROTOCOL"
     example: "openshift.DNS_PING"
     description: JGroups protocol to use for node discovery. Can be either openshift.DNS_PING or kubernetes.KUBE_PING.

--- a/jboss/container/wildfly/launch/jgroups/test/ha.bats
+++ b/jboss/container/wildfly/launch/jgroups/test/ha.bats
@@ -330,7 +330,6 @@ EOF
   CONF_AUTH_MODE="cli"
   CONFIG_ADJUSTMENT_MODE="cli"
 
-  JGROUPS_ENCRYPT_SECRET="encrypt_secret"
   JGROUPS_ENCRYPT_NAME="encrypt_name"
   JGROUPS_ENCRYPT_PASSWORD="encrypt_password"
   JGROUPS_ENCRYPT_KEYSTORE="encrypt_keystore"

--- a/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
+++ b/jboss/container/wildfly/launch/jgroups/test/jgroups.bats
@@ -139,43 +139,49 @@ EOF
 }
 
 @test "Test validate keystore - valid" {
-  run validate_keystore "encrypt_secret" "encrypt_name" "encrypt_password" "encrypt_keystore"
+  run validate_keystore "encrypt_name" "encrypt_password" "encrypt_keystore"
   echo "${output}"
   [ "${output}" = "valid" ]
 }
 
 @test "Test validate keystore - missing JGROUPS_ENCRYPT_NAME" {
-  run validate_keystore "encrypt_secret" "" "encrypt_password" "encrypt_keystore"
+  run validate_keystore "" "encrypt_password" "encrypt_keystore"
   echo "${output}"
   [ "${output}" = "partial" ]
 }
 
 @test "Test validate keystore - missing JGROUPS_ENCRYPT_PASSWORD" {
-  run validate_keystore "encrypt_secret" "encrypt_name" "" "encrypt_keystore"
+  run validate_keystore "encrypt_name" "" "encrypt_keystore"
   echo "${output}"
   [ "${output}" = "partial" ]
 }
 
-@test "Test validate keystore - missing JGROUPS_ENCRYPT_NAME and JGROUPS_ENCRYPT_SECRET" {
-  run validate_keystore "" "" "encrypt_password" "encrypt_keystore"
+@test "Test validate keystore - missing JGROUPS_ENCRYPT_KEYSTORE" {
+  run validate_keystore "encrypt_name" "encrypt_password" ""
+  echo "${output}"
+  [ "${output}" = "partial" ]
+}
+
+@test "Test validate keystore - missing all" {
+  run validate_keystore "" "" ""
   echo "${output}"
   [ "${output}" = "missing" ]
 }
 
 @test "Test validate keystore legacy" {
-  run validate_keystore_legacy "encrypt_secret" "encrypt_name" "encrypt_password" "encrypt_keystore" "encrypt_keystore_dir"
+  run validate_keystore_legacy "encrypt_name" "encrypt_password" "encrypt_keystore" "encrypt_keystore_dir"
   echo "${output}"
   [ "${output}" = "valid" ]
 }
 
 @test "Test validate keystore legacy - missing JGROUPS_ENCRYPT_KEYSTORE_DIR" {
-  run validate_keystore_legacy "encrypt_secret" "encrypt_name" "encrypt_password" "encrypt_keystore" ""
+  run validate_keystore_legacy "encrypt_name" "encrypt_password" "encrypt_keystore" ""
   echo "${output}"
   [ "${output}" = "partial" ]
 }
 
-@test "Test validate keystore legacy - missing JGROUPS_ENCRYPT_KEYSTORE_DIR and JGROUPS_ENCRYPT_SECRET" {
-  run validate_keystore_legacy "" "encrypt_name" "encrypt_password" "encrypt_keystore" ""
+@test "Test validate keystore legacy - missing all" {
+  run validate_keystore_legacy "" "" "" ""
   echo "${output}"
   [ "${output}" = "missing" ]
 }
@@ -186,7 +192,6 @@ EOF
     echo '<!-- ##JGROUPS_ENCRYPT## -->' >> ${CONFIG_FILE}
 
     JGROUPS_ENCRYPT_PROTOCOL=
-    JGROUPS_ENCRYPT_SECRET=
     JGROUPS_ENCRYPT_NAME=
     JGROUPS_ENCRYPT_PASSWORD=
     JGROUPS_ENCRYPT_KEYSTORE=
@@ -211,7 +216,6 @@ EOF
     echo '<!-- ##JGROUPS_ENCRYPT## -->' >> ${CONFIG_FILE}
 
     JGROUPS_ENCRYPT_PROTOCOL=SYM_ENCRYPT
-    JGROUPS_ENCRYPT_SECRET="encrypt_secret"
     JGROUPS_ENCRYPT_NAME="encrypt_name"
     JGROUPS_ENCRYPT_PASSWORD="encrypt_password"
     JGROUPS_ENCRYPT_KEYSTORE="encrypt_keystore"
@@ -233,7 +237,6 @@ EOF
     echo '<!-- ##JGROUPS_ENCRYPT## -->' >> ${CONFIG_FILE}
 
     JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT
-    JGROUPS_ENCRYPT_SECRET=
     JGROUPS_ENCRYPT_NAME=
     JGROUPS_ENCRYPT_PASSWORD=
     JGROUPS_ENCRYPT_KEYSTORE=
@@ -261,7 +264,6 @@ EOF
     echo '<!-- ##JGROUPS_ENCRYPT## -->' >> ${CONFIG_FILE}
 
     JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT
-    JGROUPS_ENCRYPT_SECRET="encrypt_secret"
     JGROUPS_ENCRYPT_NAME="encrypt_name"
     JGROUPS_ENCRYPT_PASSWORD="encrypt_password"
     JGROUPS_ENCRYPT_KEYSTORE="encrypt_keystore"
@@ -385,7 +387,6 @@ EOF
   JGROUPS_ENCRYPT_PROTOCOL="ASYM_ENCRYPT"
   JGROUPS_CLUSTER_PASSWORD="p@ssw0rd"
 
-  JGROUPS_ENCRYPT_SECRET="app-secret"
   JGROUPS_ENCRYPT_NAME="jgroups"
   JGROUPS_ENCRYPT_PASSWORD="p@ssw0rd"
   JGROUPS_ENCRYPT_KEYSTORE="jgroups.jceks"
@@ -438,7 +439,6 @@ EOF
   CONFIG_ADJUSTMENT_MODE="cli"
 
   JGROUPS_ENCRYPT_PROTOCOL="SYM_ENCRYPT"
-  JGROUPS_ENCRYPT_SECRET="encrypt_secret"
   JGROUPS_ENCRYPT_NAME="encrypt_name"
   JGROUPS_ENCRYPT_PASSWORD="encrypt_password"
   JGROUPS_ENCRYPT_KEYSTORE="encrypt_keystore"
@@ -486,7 +486,6 @@ EOF
   CONFIG_ADJUSTMENT_MODE="cli"
 
   JGROUPS_ENCRYPT_PROTOCOL="SYM_ENCRYPT"
-  JGROUPS_ENCRYPT_SECRET="encrypt_secret"
   JGROUPS_ENCRYPT_NAME="encrypt_name"
   JGROUPS_ENCRYPT_PASSWORD="encrypt_password"
   JGROUPS_ENCRYPT_KEYSTORE="encrypt_keystore"


### PR DESCRIPTION
Removing checks of JGROUPS_ENCRYPT_SECRET, this env variable is actually no more in context (using helm Charts, no more template).
