### PR TITLE
Fix for #348, Unset socket-binding attribute for FD_SOCK protocol, required for 27 Beta1

### DIFF
--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/finalize-script/added/src/main/resources/resources/wildfly/scripts/finalize.cli
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/finalize-script/added/src/main/resources/resources/wildfly/scripts/finalize.cli
@@ -10,6 +10,22 @@ if (outcome == success) of /subsystem=jgroups/stack=tcp/protocol=MPING:read-reso
   /subsystem=jgroups/stack=tcp/protocol=MPING:remove
 end-if
 
+if (outcome == success) of /subsystem=jgroups/stack=udp/protocol=FD_SOCK:read-resource
+ /subsystem=jgroups/stack=udp/protocol=FD_SOCK:write-attribute(name=socket-binding)
+end-if
+
+if (outcome == success) of /subsystem=jgroups/stack=tcp/protocol=FD_SOCK:read-resource
+  /subsystem=jgroups/stack=tcp/protocol=FD_SOCK:write-attribute(name=socket-binding)
+end-if
+
+if (outcome == success) of /subsystem=jgroups/stack=udp/protocol=FD_SOCK2:read-resource
+ /subsystem=jgroups/stack=udp/protocol=FD_SOCK2:write-attribute(name=socket-binding)
+end-if
+
+if (outcome == success) of /subsystem=jgroups/stack=tcp/protocol=FD_SOCK2:read-resource
+  /subsystem=jgroups/stack=tcp/protocol=FD_SOCK2:write-attribute(name=socket-binding)
+end-if
+
 if (outcome == success) of /socket-binding-group=standard-sockets/socket-binding=jgroups-udp-fd:read-resource
   /socket-binding-group=standard-sockets/socket-binding=jgroups-udp-fd:remove
 end-if


### PR DESCRIPTION
For both FD_SOCK and FD_SOCK2, unset the socket binding attribute prior to socket-binding removal. 