### PR TITLE
Fix for Issue #350, http and https listener should be bound to 0.0.0.0

### DIFF
--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-socket.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-socket.xml
@@ -4,4 +4,8 @@
         <param name="socket-binding-group" value="standard-sockets" />
         <param name="port-offset" value="0"/>
     </feature>
+    <feature spec="interface">
+        <param name="interface" value="bindall"/>
+        <param name="inet-address" value="${jboss.bind.address.bindall:0.0.0.0}"/>
+    </feature>
 </feature-group-spec>

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
@@ -10,4 +10,14 @@
             </feature>
         </feature>
     </feature>
+        <feature spec="socket-binding-group.socket-binding">
+        <param name="socket-binding-group" value="standard-sockets" />
+        <param name="socket-binding" value="http"/>
+        <param name="interface" value="bindall"/>
+    </feature>
+    <feature spec="socket-binding-group.socket-binding">
+        <param name="socket-binding-group" value="standard-sockets" />
+        <param name="socket-binding" value="https"/>
+        <param name="interface" value="bindall"/>
+    </feature>
 </feature-group-spec>

--- a/jboss/container/wildfly/run/api/module.yaml
+++ b/jboss/container/wildfly/run/api/module.yaml
@@ -25,6 +25,6 @@ envs:
 - name: SERVER_LAUNCH_SCRIPT_OVERRIDE
   description: In order to override the server launch script called by the image entry-point, set this env variable to the name of a bash file located in the '$JBOSS_HOME/bin' directory.
 - name: SERVER_MANAGEMENT_BIND_ADDRESS
-  description: By default the public interface is bound to 0:0:0:0 address. You can change this default using this env variable.
+  description: By default the management interface is bound to 0.0.0.0 address. You can change this default using this env variable.
 - name: SERVER_PUBLIC_BIND_ADDRESS
   description: By default the public interface is bound to the hostname ip address. You can change this default using this env variable.


### PR DESCRIPTION
Introduce a bindall interface, make http/https socket-binding to depend on it.
This change impacts all galleon layers provisioned with the wildfly-cloud-galleon-pack.