### PR TITLE
Add a clarifying TESTING.md document to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wildfly-cekit-modules
 
-A set of [CEKit](https://github.com/cekit/cekitmodules) used to build [WildFly S2I](https://github.com/wildfly/wildfly-s2i/)
+A set of [CEKit](https://github.com/cekit/cekitmodules) modules used to build [WildFly S2I](https://github.com/wildfly/wildfly-s2i/)
 images and [WildFly Cloud Galleon feature-pack](https://github.com/wildfly-extras/wildfly-cloud-galleon-pack).
 
 These CEKit modules cover:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,21 @@
+# wildfly-cekit-module testing
+
+Tests are provided for modules defined in this repository.
+
+Tests are based on the [Bash Automated Testing System](https://github.com/bats-core/bats-core) framework which 
+permits defining, executing and reporting on tests implemented as generized bash scripts.
+
+The tests can be used to start a container image with a set of pre-defined parameters, load the module to be tested 
+and then test assertions on the effect of the module on the container image. By convention, tests are included in the _tests_ sub-directory of the directory containing the module definition file.
+
+These tests are aimed at validating the configurational integrity of the module; in other words,
+to validate that the effect of adding the module to the image definition file is
+as expected. These assertions include, but are not limited to, checking that image configuration files have been
+correctly updated for execution the cloud. 
+
+
+
+
+
+
+


### PR DESCRIPTION
I feel there is a need to clarify the scope and extent of testing carried out in this repo, so that people are clear on what exactly is being tested and why. 
I have put together a sketch of what might be included in such a document, based on my limited knowledge of the testing framework and approach, please correct as necessary. 
I have called this type of testing "configurational integrity" testing, to emphasize that the focus is on testing the effects that these cekit modules have on the configuration of an image that includes them, and not on testing of the functional behavior of the image when running in the cloud. 
