### PR TITLE
Remove code to exclude ha sockets

### DIFF
--- a/.github/workflows/test-wildfly-s2i.yml
+++ b/.github/workflows/test-wildfly-s2i.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Additional Tests
         if: env.IMPACT_IMAGE == 'true'
         run: |
-          export IMAGE_VERSION=$(yq e ".version" jdk11-overrides.yaml)
+          export IMAGE_VERSION=$(yq e ".version" wildfly-runtime-image/jdk11-overrides.yaml)
           export NAMESPACE=wildfly
           export IMAGE_NAME=${NAMESPACE}/wildfly-s2i
           export RUNTIME_IMAGE_NAME=${NAMESPACE}/wildfly-runtime

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/feature_groups/os-clustering.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/feature_groups/os-clustering.xml
@@ -11,9 +11,6 @@
     <!-- ha sockets -->
     <feature spec="socket-binding-group">
         <param name="socket-binding-group" value="standard-sockets"/>
-        <feature-group name="ha-sockets">
-            <exclude feature-id="socket-binding-group.socket-binding:name=standard-sockets,socket-binding=jgroups-udp-fd"/>
-            <exclude feature-id="socket-binding-group.socket-binding:name=standard-sockets,socket-binding=jgroups-tcp-fd"/>
-        </feature-group>
+        <feature-group name="ha-sockets"/>
     </feature>
 </feature-group-spec>

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -10,6 +10,4 @@
     <exclude feature-id="subsystem.jgroups.stack.protocol:stack=udp,protocol=PING"/>
     <exclude feature-id="subsystem.jgroups.stack.protocol.MPING:stack=tcp"/>
 
-    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-udp-fd"/>
-    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-tcp-fd"/>
 </layer-spec>

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
@@ -10,9 +10,6 @@
     <exclude feature-id="subsystem.jgroups.stack.protocol:stack=udp,protocol=PING"/>
     <exclude feature-id="subsystem.jgroups.stack.protocol.MPING:stack=tcp"/>
     
-    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-udp-fd"/>
-    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-tcp-fd"/>
-    
     <feature-group name="os-infinispan-hibernate"/>
 
 </layer-spec>

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
@@ -9,9 +9,6 @@
 
     <exclude feature-id="subsystem.jgroups.stack.protocol:stack=udp,protocol=PING"/>
     <exclude feature-id="subsystem.jgroups.stack.protocol.MPING:stack=tcp"/>
-    
-    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-udp-fd"/>
-    <exclude feature-id="socket-binding-group.socket-binding:socket-binding-group=standard-sockets,socket-binding=jgroups-tcp-fd"/>
 
     <feature-group name="os-infinispan-web-repl-cache"/>
 </layer-spec>


### PR DESCRIPTION
These excludes are left over from https://github.com/wildfly/wildfly-cekit-modules/pull/362.
Could have a side effect when provisioning cloud FP alone.