### PR TITLE
[JBEAP-25347] Remove deprecation warning for S2I provisioning env vars

### DIFF
--- a/jboss/container/wildfly/s2i/2.0/legacy/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
+++ b/jboss/container/wildfly/s2i/2.0/legacy/artifacts/opt/jboss/container/wildfly/s2i/assemble.sh
@@ -50,8 +50,7 @@ else
   # Required to handle custom feature-pack copied to local maven repo
   source "${JBOSS_CONTAINER_WILDFLY_S2I_LEGACY_GALLEON_MODULE}/s2i_galleon"
   if [ -n "${GALLEON_PROVISION_FEATURE_PACKS}" ] || [ -n "${GALLEON_USE_LOCAL_FILE}" ]; then
-    log_warning "You have activated legacy s2i workflow by setting GALLEON_PROVISION_FEATURE_PACKS or GALLEON_USE_LOCAL_FILE env variable."
-    log_warning "This support is deprecated and will be removed in a future release. Provision and configure your server during s2i from your pom.xml file by using the dedicated Maven plugin."
+    log_info "You have activated legacy s2i workflow by setting GALLEON_PROVISION_FEATURE_PACKS or GALLEON_USE_LOCAL_FILE env variable."
     # images using this module must have set these env variables.
     if [ -z "${PROVISIONING_MAVEN_PLUGIN_GROUP_ID}" ] || [ -z "${PROVISIONING_MAVEN_PLUGIN_ARTIFACT_ID}" ] || [ -z "${PROVISIONING_MAVEN_PLUGIN_VERSION}" ]; then
       log_error "PROVISIONING_MAVEN_PLUGIN_GROUP_ID,  PROVISIONING_MAVEN_PLUGIN_ARTIFACT_ID and PROVISIONING_MAVEN_PLUGIN_VERSION env variable must be set to provision a server."


### PR DESCRIPTION
* Remove the deprecation warning when the S2I env vars `GALLEON_PROVISION_FEATURE_PACKS` or `GALLEON_USE_LOCAL_FILE` are used
* Change the warning log to an info log as this is a valid use case to use these env vars to create an application image without access to the source code of the Jakarta EE application

JIRA: https://issues.redhat.com/browse/JBEAP-25347