### PR TITLE
CLOUD-4174 Session affinity information is attached to the session ID but never used

### DIFF
--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
@@ -3,20 +3,20 @@
 <feature-group-spec name="os-undertow" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="subsystem.undertow">
         <feature spec="subsystem.undertow.server">
-            <param name="server" value="default-server" />
+            <param name="server" value="default-server"/>
             <feature spec="subsystem.undertow.server.http-listener">
                 <param name="http-listener" value="default"/>
                 <param name="proxy-address-forwarding" value="true"/>
             </feature>
         </feature>
     </feature>
-        <feature spec="socket-binding-group.socket-binding">
-        <param name="socket-binding-group" value="standard-sockets" />
+    <feature spec="socket-binding-group.socket-binding">
+        <param name="socket-binding-group" value="standard-sockets"/>
         <param name="socket-binding" value="http"/>
         <param name="interface" value="bindall"/>
     </feature>
     <feature spec="socket-binding-group.socket-binding">
-        <param name="socket-binding-group" value="standard-sockets" />
+        <param name="socket-binding-group" value="standard-sockets"/>
         <param name="socket-binding" value="https"/>
         <param name="interface" value="bindall"/>
     </feature>

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
@@ -9,6 +9,12 @@
                 <param name="proxy-address-forwarding" value="true"/>
             </feature>
         </feature>
+        <feature spec="subsystem.undertow.servlet-container">
+            <param name="servlet-container" value="default"/>
+            <feature spec="subsystem.undertow.servlet-container.setting.affinity-cookie">
+                <param name="name" value="INGRESSCOOKIE"/>
+            </feature>
+        </feature>
     </feature>
     <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding-group" value="standard-sockets"/>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/CLOUD-4174