### PR TITLE
Fix for Issue #387, keycloak SAML automatic registration uses wrong JBoss Modules module name

### DIFF
--- a/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
+++ b/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
@@ -230,7 +230,7 @@ function configure_SAML_elytron() {
   id=$1
   cli="
 if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm-$id:read-resource
-    /subsystem=elytron/custom-realm=KeycloakSAMLRealm-$id:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+    /subsystem=elytron/custom-realm=KeycloakSAMLRealm-$id:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
     echo Keycloak SAML Realm already installed >> \${warning_file}
 end-if
@@ -249,7 +249,7 @@ else
 end-if
 
 if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-$id:read-resource
-    /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-$id:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+    /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-$id:add(module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
     echo Keycloak SAML HTTP Mechanism Factory already installed >> \${warning_file}
 end-if


### PR DESCRIPTION
Keycloak SAML feature-pack 22.0.1 has a module renaming that breaks the feature.