### PR TITLE
[0.29.alpha1.x] JBEAP-25437 Session affinity information is attached to the session ID but never used

### DIFF
--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/base/added/src/main/resources/feature_groups/os-undertow.xml
@@ -9,6 +9,12 @@
                 <param name="proxy-address-forwarding" value="true"/>
             </feature>
         </feature>
+        <feature spec="subsystem.undertow.servlet-container">
+            <param name="servlet-container" value="default"/>
+            <feature spec="subsystem.undertow.servlet-container.setting.affinity-cookie">
+                <param name="name" value="INGRESSCOOKIE"/>
+            </feature>
+        </feature>
     </feature>
     <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding-group" value="standard-sockets"/>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/JBEAP-25437

Upstream PR 
https://github.com/wildfly/wildfly-cekit-modules/pull/385

Upstream issue
https://issues.redhat.com/browse/CLOUD-4174