### PR TITLE
Fix for JBEAP-30682, change back the keycloak elytron module name to keycloak-saml-wildfly-elytron-jakarta-adapter required for Keyclaok 22.x

### DIFF
--- a/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
+++ b/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
@@ -236,9 +236,15 @@ echo "$cli"
 
 function configure_SAML_elytron() {
   id=$1
+  keycloak26ModuleName="keycloak-saml-wildfly-elytron-adapter"
+  moduleName="keycloak-saml-wildfly-elytron-jakarta-adapter"
+  if [ -d "${JBOSS_HOME}/modules/system/add-ons/keycloak/org/keycloak/$keycloak26ModuleName" ]; then
+    moduleName=$keycloak26ModuleName 
+  fi
+  fullModuleName="org.keycloak.$moduleName"
   cli="
 if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm-$id:read-resource
-    /subsystem=elytron/custom-realm=KeycloakSAMLRealm-$id:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+    /subsystem=elytron/custom-realm=KeycloakSAMLRealm-$id:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=$fullModuleName)
 else
     echo Keycloak SAML Realm already installed >> \${warning_file}
 end-if
@@ -257,7 +263,7 @@ else
 end-if
 
 if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-$id:read-resource
-    /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-$id:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+    /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-$id:add(module=$fullModuleName)
 else
     echo Keycloak SAML HTTP Mechanism Factory already installed >> \${warning_file}
 end-if

--- a/jboss/container/wildfly/launch/keycloak/2.0/tests/bats/keycloak.bats
+++ b/jboss/container/wildfly/launch/keycloak/2.0/tests/bats/keycloak.bats
@@ -71,7 +71,7 @@ if (outcome != success) of /extension=org.keycloak.keycloak-saml-adapter-subsyst
 /extension=org.keycloak.keycloak-saml-adapter-subsystem:add()
 end-if
 if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:read-resource
-/subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+/subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
 echo Keycloak SAML Realm already installed >> \${warning_file}
 end-if
@@ -87,7 +87,7 @@ else
 echo Keycloak SAML Realm Mapper already installed >> \${warning_file}
 end-if
 if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:read-resource
-/subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+/subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:add(module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
 echo Keycloak SAML HTTP Mechanism Factory already installed >> \${warning_file}
 end-if
@@ -161,7 +161,7 @@ if (outcome != success) of /extension=org.keycloak.keycloak-saml-adapter-subsyst
 /extension=org.keycloak.keycloak-saml-adapter-subsystem:add()
 end-if
 if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:read-resource
-/subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+/subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
 echo Keycloak SAML Realm already installed >> \${warning_file}
 end-if
@@ -177,7 +177,7 @@ else
 echo Keycloak SAML Realm Mapper already installed >> \${warning_file}
 end-if
 if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:read-resource
-/subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+/subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:add(module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
 echo Keycloak SAML HTTP Mechanism Factory already installed >> \${warning_file}
 end-if
@@ -243,7 +243,7 @@ if (outcome != success) of /extension=org.keycloak.keycloak-saml-adapter-subsyst
 /extension=org.keycloak.keycloak-saml-adapter-subsystem:add()
 end-if
 if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:read-resource
-/subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+/subsystem=elytron/custom-realm=KeycloakSAMLRealm-test:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
 echo Keycloak SAML Realm already installed >> \${warning_file}
 end-if
@@ -259,7 +259,7 @@ else
 echo Keycloak SAML Realm Mapper already installed >> \${warning_file}
 end-if
 if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:read-resource
-/subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+/subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory-test:add(module=org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter)
 else
 echo Keycloak SAML HTTP Mechanism Factory already installed >> \${warning_file}
 end-if


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-30682