### PR TITLE
[JBEAP-31790] (8.0.z) replicated-cache created by web-clustering Galleon layer does not include purge/passivation settings for the file-store

### DIFF
--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/feature_groups/os-infinispan-web-repl-cache.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/feature_groups/os-infinispan-web-repl-cache.xml
@@ -17,6 +17,8 @@
                 </feature>
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.store.file">
                     <unset param="relative-to"/>
+                    <param name="purge" value="true"/>
+                    <param name="passivation" value="true"/>
                 </feature>
             </feature>
         </feature>

--- a/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/feature_groups/os-infinispan.xml
+++ b/jboss/container/wildfly/galleon/cloud-galleon-pack/layers/clustering/added/src/main/resources/feature_groups/os-infinispan.xml
@@ -22,6 +22,8 @@
                 </feature>
                 <feature spec="subsystem.infinispan.cache-container.replicated-cache.store.file">
                     <unset param="relative-to"/>
+                    <param name="purge" value="true"/>
+                    <param name="passivation" value="true"/>
                 </feature>
             </feature>
         </include>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBEAP-31790