### PR TITLE
UBI10, jvm_specific_diagnostics has been removed (OPENJDK-4030)

### DIFF
--- a/jboss/container/wildfly/run/1.0/common/artifacts/opt/jboss/container/wildfly/run/run
+++ b/jboss/container/wildfly/run/1.0/common/artifacts/opt/jboss/container/wildfly/run/run
@@ -34,12 +34,15 @@ GC_METASPACE_SIZE=${GC_METASPACE_SIZE:-96}
 
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 
-# If JAVA_DIAGNOSTICS and there is jvm_specific_diagnostics, move the settings to PREPEND_JAVA_OPTS
-# to bypass the specific EAP checks done on JAVA_OPTS in standalone.sh that could remove the GC EAP specific log configurations
-JVM_SPECIFIC_DIAGNOSTICS=$(jvm_specific_diagnostics)
-if [ "x$JAVA_DIAGNOSTICS" != "x" ] && [ "x{JVM_SPECIFIC_DIAGNOSTICS}" != "x" ]; then
-  JAVA_OPTS=${JAVA_OPTS/${JVM_SPECIFIC_DIAGNOSTICS} /}
-  PREPEND_JAVA_OPTS="${JVM_SPECIFIC_DIAGNOSTICS} ${PREPEND_JAVA_OPTS}"
+# Has been removed for UBI10 openjdk support
+if [ -n "$(type -t jvm_specific_diagnostics)" ]; then
+  # If JAVA_DIAGNOSTICS and there is jvm_specific_diagnostics, move the settings to PREPEND_JAVA_OPTS
+  # to bypass the specific EAP checks done on JAVA_OPTS in standalone.sh that could remove the GC EAP specific log configurations
+  JVM_SPECIFIC_DIAGNOSTICS=$(jvm_specific_diagnostics)
+  if [ "x$JAVA_DIAGNOSTICS" != "x" ] && [ "x{JVM_SPECIFIC_DIAGNOSTICS}" != "x" ]; then
+    JAVA_OPTS=${JAVA_OPTS/${JVM_SPECIFIC_DIAGNOSTICS} /}
+    PREPEND_JAVA_OPTS="${JVM_SPECIFIC_DIAGNOSTICS} ${PREPEND_JAVA_OPTS}"
+  fi
 fi
 
 # Make sure that we use /dev/urandom (CLOUD-422)


### PR DESCRIPTION
Check that jvm_specific_diagnostics method exists, has been removed for ubi10 support.